### PR TITLE
Adaptive Screen Size

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,25 +1,13 @@
 """Sets up the server for the Dash app."""
 import dash  # type: ignore
-from dash import Dash, dcc, html  # type: ignore
+from dash import Dash, html  # type: ignore
 
 app = Dash(__package__, use_pages=True, update_title=None)
 
 app.layout = html.Div(
     style={"backgroundColor": "#F9F9F9"},
     children=[
-        html.H1("Multi-page app with Dash Pages"),
-        html.Div(
-            [
-                html.Div(
-                    dcc.Link(
-                        f"{page['name']} - {page['path']}", href=page["relative_path"]
-                    )
-                )
-                for page in dash.page_registry.values()
-            ]
-        ),
         dash.page_container,
-        html.H2("Footer", style={"float": "right", "backgroundColor": "#F9F9F9"}),
     ],
 )
 

--- a/app/app.py
+++ b/app/app.py
@@ -6,8 +6,7 @@ app = Dash(__package__, use_pages=True, update_title=None)
 
 app.layout = html.Div(
     style={
-        "display": "flex",
-        "flex-direction": "column",
+        "backgroundColor": "#F9F9F9",
         "height": "100%",
     },
     children=[

--- a/app/app.py
+++ b/app/app.py
@@ -5,7 +5,11 @@ from dash import Dash, html  # type: ignore
 app = Dash(__package__, use_pages=True, update_title=None)
 
 app.layout = html.Div(
-    style={"backgroundColor": "#F9F9F9"},
+    style={
+        "display": "flex",
+        "flex-direction": "column",
+        "height": "100%",
+    },
     children=[
         dash.page_container,
     ],

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -133,13 +133,6 @@ total_dem_fig = generate_total_dem_fig(df)
 system_freq_fig = generate_system_freq_fig(df)
 
 layout = html.Div(
-    className="test-class",
-    style={
-        "display": "flex",
-        "flex-direction": "column",
-        "height": "100%",
-        "backgroundColor": "#F9F9F9",
-    },
     children=[
         html.Div(
             style={"display": "flex", "justify-content": "space-around"},

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -133,6 +133,11 @@ total_dem_fig = generate_total_dem_fig(df)
 system_freq_fig = generate_system_freq_fig(df)
 
 layout = html.Div(
+    style={
+        "display": "flex",
+        "flex-direction": "column",
+        "justify-content": "space-around",
+    },
     children=[
         html.Div(
             style={"display": "flex", "justify-content": "space-around"},

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -133,9 +133,14 @@ total_dem_fig = generate_total_dem_fig(df)
 system_freq_fig = generate_system_freq_fig(df)
 
 layout = html.Div(
-    className='test-class',
-    style={"display": "flex", "flex-direction": "column", "height": "100%", "backgroundColor": "#F9F9F9"},
-    children = [
+    className="test-class",
+    style={
+        "display": "flex",
+        "flex-direction": "column",
+        "height": "100%",
+        "backgroundColor": "#F9F9F9",
+    },
+    children=[
         html.Div(
             style={"display": "flex", "justify-content": "space-around"},
             children=[
@@ -191,7 +196,7 @@ layout = html.Div(
             ],
         ),
         dcc.Interval(id="interval", interval=interval),
-    ]
+    ],
 )
 
 

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -133,22 +133,32 @@ total_dem_fig = generate_total_dem_fig(df)
 system_freq_fig = generate_system_freq_fig(df)
 
 layout = html.Div(
-    [
+    className='test-class',
+    style={"display": "flex", "flex-direction": "column", "height": "100%", "backgroundColor": "#F9F9F9"},
+    children = [
         html.Div(
             style={"display": "flex", "justify-content": "space-around"},
             children=[
                 html.Div(
-                    style={"width": "45%"},
+                    style={"width": "48%"},
                     children=[
                         html.H1("Generation Split"),
-                        dcc.Graph(id="graph-gen-split", figure=gen_split_fig),
+                        dcc.Graph(
+                            id="graph-gen-split",
+                            figure=gen_split_fig,
+                            style={"height": "40vh"},
+                        ),
                     ],
                 ),
                 html.Div(
-                    style={"width": "45%"},
+                    style={"width": "48%"},
                     children=[
                         html.H1("Generation Total"),
-                        dcc.Graph(id="graph-gen-total", figure=total_gen_fig),
+                        dcc.Graph(
+                            id="graph-gen-total",
+                            figure=total_gen_fig,
+                            style={"height": "40vh"},
+                        ),
                     ],
                 ),
             ],
@@ -157,17 +167,25 @@ layout = html.Div(
             style={"display": "flex", "justify-content": "space-around"},
             children=[
                 html.Div(
-                    style={"width": "45%"},
+                    style={"width": "48%"},
                     children=[
                         html.H1("Demand Total"),
-                        dcc.Graph(id="graph-demand", figure=total_dem_fig),
+                        dcc.Graph(
+                            id="graph-demand",
+                            figure=total_dem_fig,
+                            style={"height": "40vh"},
+                        ),
                     ],
                 ),
                 html.Div(
-                    style={"width": "45%"},
+                    style={"width": "48%"},
                     children=[
                         html.H1("System Frequency"),
-                        dcc.Graph(id="graph-freq", figure=system_freq_fig),
+                        dcc.Graph(
+                            id="graph-freq",
+                            figure=system_freq_fig,
+                            style={"height": "40vh"},
+                        ),
                     ],
                 ),
             ],


### PR DESCRIPTION
Height and width of graph elements adjusted for `/supplydemand` so it should fit everything when full-screened without a scroll bar. Page directory and footer have also been removed.

I've only been able to test this on my 1080p laptop monitor, but that should suffice for the majority of the display screens. There is also a weird bit of white space at the bottom of the page that I can't figure out how to remove. Seems to be a `div` at a higher level than the app itself.

Closes #43 