### PR TITLE
Fix Issue where the OVE spaces are not linking to the dash app on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.10
 COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 COPY ./app/ ./app
-CMD python -m app.core_api; gunicorn -b 0.0.0.0:8050 app.app:server
+CMD python -m app.core_api; gunicorn --reload -b 0.0.0.0:8050 app.app:server

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.10
 COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 COPY ./app/ ./app
-CMD python app/core_api.py; gunicorn --reload -b 0.0.0.0:8050 app.app:server
+CMD python -m app.core_api; gunicorn -b 0.0.0.0:8050 app.app:server

--- a/app/core_api.py
+++ b/app/core_api.py
@@ -108,7 +108,7 @@ INIT_SECTIONS = {
 
 def wait_for_ove() -> None:
     """Function to wait for the OVE Core API to be available after startup."""
-    while requests.get(API_URL).status_code != 200:
+    while requests.get(f"{API_URL}/app/html").status_code != 200:
         time.sleep(5)
 
 


### PR DESCRIPTION
# Description

The key here was that the OVE Apps API was not ready to receive requests yet. Previously it was waiting for the OVE Core to be ready, but that was ready for the OVE Apps.

Close #53 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [x] Pre-commit hooks run successfully (`pre-commit run --all-files`)