### PR TITLE
Create data module

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,9 +1,12 @@
 """Sets up the server for the Dash app."""
 import dash  # type: ignore
-from dash import Dash, html  # type: ignore
+from dash import Dash, dcc, html  # type: ignore
 
 from . import log
-from .data import data_div
+
+##################
+interval = 7000
+##################
 
 app = Dash(__package__, use_pages=True, update_title=None)
 
@@ -14,7 +17,7 @@ app.layout = html.Div(
     },
     children=[
         dash.page_container,
-        data_div,
+        dcc.Interval(id="figure_interval", interval=interval),
     ],
 )
 

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ import dash  # type: ignore
 from dash import Dash, html  # type: ignore
 
 from . import log
+from .data import data_div
 
 app = Dash(__package__, use_pages=True, update_title=None)
 
@@ -13,6 +14,7 @@ app.layout = html.Div(
     },
     children=[
         dash.page_container,
+        data_div,
     ],
 )
 

--- a/app/data.py
+++ b/app/data.py
@@ -1,6 +1,6 @@
 """Calls the Datahub to update data."""
 import pandas as pd
-from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash import Input, Output, callback, dcc  # type: ignore
 from dash.exceptions import PreventUpdate  # type: ignore
 
 from . import LIVE_MODEL, log
@@ -10,19 +10,15 @@ from .datahub_api import get_opal_data  # , get_dsr_data
 interval = 7000
 ##################
 
-df_opal = pd.DataFrame({"Col": [0]})
+DF_OPAL = pd.DataFrame({"Col": [0]})
 
-data_div = html.Div(
-    children=[
-        dcc.Interval(id="interval", interval=interval),
-        dcc.Store(id="data_opal", data=df_opal.to_dict(orient="records")),
-    ]
-)
+data_interval = dcc.Interval(id="data_interval", interval=interval)
+empty_output = dcc.Store(id="empty", data=[])
 
 
 @callback(
-    [Output("data_opal", "data")],
-    [Input("interval", "n_intervals")],
+    [Output("empty", "data")],
+    [Input("data_interval", "n_intervals")],
 )
 def update_data(n_intervals: int) -> tuple[list[dict[str, object]],]:
     """Function to update the data.
@@ -35,16 +31,18 @@ def update_data(n_intervals: int) -> tuple[list[dict[str, object]],]:
         Opal data dictionary
 
     """
+    global DF_OPAL
+
     if n_intervals is None:
         raise PreventUpdate
 
     if LIVE_MODEL:
         log.debug("Updating plots from live model")
         data_opal = get_opal_data()
-        new_df_opal = pd.DataFrame(**data_opal)  # type: ignore[call-overload]
+        DF_OPAL = pd.DataFrame(**data_opal)  # type: ignore[call-overload]
     else:
         from .pre_set_data import OPAL_DATA
 
         log.debug("Updating plots with pre-set data")
-        new_df_opal = OPAL_DATA.loc[:n_intervals]
-    return (new_df_opal.to_dict(orient="records"),)
+        DF_OPAL = OPAL_DATA.loc[:n_intervals]
+    return ([],)

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,50 @@
+"""Calls the Datahub to update data."""
+import pandas as pd
+from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash.exceptions import PreventUpdate  # type: ignore
+
+from . import LIVE_MODEL, log
+from .datahub_api import get_opal_data  # , get_dsr_data
+
+##################
+interval = 7000
+##################
+
+df_opal = pd.DataFrame({"Col": [0]})
+
+data_div = html.Div(
+    children=[
+        dcc.Interval(id="interval", interval=interval),
+        dcc.Store(id="data_opal", data=df_opal.to_dict(orient="records")),
+    ]
+)
+
+
+@callback(
+    [Output("data_opal", "data")],
+    [Input("interval", "n_intervals")],
+)
+def update_data(n_intervals: int) -> tuple[list[dict[str, object]],]:
+    """Function to update the data.
+
+    Args:
+        n_intervals (int): The number of times this page has updated.
+            indexes by 1 every 7 seconds.
+
+    Returns:
+        Opal data dictionary
+
+    """
+    if n_intervals is None:
+        raise PreventUpdate
+
+    if LIVE_MODEL:
+        log.debug("Updating plots from live model")
+        data_opal = get_opal_data()
+        new_df_opal = pd.DataFrame(**data_opal)  # type: ignore[call-overload]
+    else:
+        from .pre_set_data import OPAL_DATA
+
+        log.debug("Updating plots with pre-set data")
+        new_df_opal = OPAL_DATA.loc[:n_intervals]
+    return (new_df_opal.to_dict(orient="records"),)

--- a/app/data.py
+++ b/app/data.py
@@ -20,7 +20,7 @@ empty_output = dcc.Store(id="empty", data=[])
     [Output("empty", "data")],
     [Input("data_interval", "n_intervals")],
 )
-def update_data(n_intervals: int) -> tuple[list[dict[str, object]],]:
+def update_data(n_intervals: int) -> tuple[list[None],]:
     """Function to update the data.
 
     Args:

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -229,30 +229,31 @@ layout = html.Div(
         Output("ev_charging_breakdown_fig", "figure"),
         Output("dsr_commands_fig", "figure"),
     ],
-    [Input("data_opal", "data")],
+    [Input("figure_interval", "n_intervals")],
 )
 def update_figures(
-    data_opal: list[dict[str, object]],
+    n_intervals: int,
 ) -> tuple[str, str, go.Figure, str, str, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        data_opal (list): Opal data
+        n_intervals (int): The number of times this page has updated.
+            indexes by 1 every 7 seconds.
 
     Returns:
         tuple[str, str, px.pie, str, str, px.pie, px.line]:
             The new figures.
     """
-    df_opal = pd.DataFrame(data_opal)
+    from ..data import DF_OPAL
 
     # TODO: ensure each figure is using the correct dataframe
-    agent_location_fig = generate_agent_location_map_img(df_opal)
-    agent_location_sld_img = generate_agent_location_sld_img(df_opal)
-    agent_activity_breakdown_fig = generate_agent_activity_breakdown_fig(df_opal)
-    ev_location_fig = generate_ev_location_map_img(df_opal)
-    ev_location_sld_img = generate_ev_location_sld_img(df_opal)
-    ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(df_opal)
-    dsr_commands_fig = generate_dsr_commands_fig(df_opal)
+    agent_location_fig = generate_agent_location_map_img(DF_OPAL)
+    agent_location_sld_img = generate_agent_location_sld_img(DF_OPAL)
+    agent_activity_breakdown_fig = generate_agent_activity_breakdown_fig(DF_OPAL)
+    ev_location_fig = generate_ev_location_map_img(DF_OPAL)
+    ev_location_sld_img = generate_ev_location_sld_img(DF_OPAL)
+    ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(DF_OPAL)
+    dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
     return (
         agent_location_fig,
         agent_location_sld_img,

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -7,6 +7,7 @@ from dash_iconify import DashIconify  # type: ignore
 
 from .. import core_api as core
 from .. import log
+from ..data import data_interval, empty_output
 
 dash.register_page(__name__)
 
@@ -193,6 +194,8 @@ layout = html.Div(
                 ),
             ],
         ),
+        data_interval,
+        empty_output,
     ],
 )
 

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -139,28 +139,29 @@ layout = html.Div(
         Output("graph-dsr", "figure"),
         Output("graph-dsr-commands", "figure"),
     ],
-    [Input("data_opal", "data")],
+    [Input("figure_interval", "n_intervals")],
 )
 def update_figures(
-    data_opal: list[dict[str, object]],
+    n_intervals: int,
 ) -> tuple[go.Figure, go.Figure, px.line, go.Figure, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        data_opal (list): Opal data
+        n_intervals (int): The number of times this page has updated.
+            indexes by 1 every 7 seconds.
 
     Returns:
         tuple[go.Figure, go.Figure, px.line, go.Figure, go.Figure, px.line]:
             The new figures.
     """
-    df_opal = pd.DataFrame(data_opal)
+    from ..data import DF_OPAL
 
-    intraday_market_sys_fig = generate_intraday_market_sys_fig(df_opal)
-    balancing_market_fig = generate_balancing_market_fig(df_opal)
-    energy_deficit_fig = generate_energy_deficit_fig(df_opal)
-    intraday_market_bids_fig = generate_intraday_market_bids_fig(df_opal)
+    intraday_market_sys_fig = generate_intraday_market_sys_fig(DF_OPAL)
+    balancing_market_fig = generate_balancing_market_fig(DF_OPAL)
+    energy_deficit_fig = generate_energy_deficit_fig(DF_OPAL)
+    intraday_market_bids_fig = generate_intraday_market_bids_fig(DF_OPAL)
     dsr_fig = generate_dsr_fig(df)  # TODO: replace with df_dsr when available
-    dsr_commands_fig = generate_dsr_commands_fig(df_opal)
+    dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
     return (
         intraday_market_sys_fig,
         balancing_market_fig,

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -12,11 +12,8 @@ import dash  # type: ignore
 import pandas as pd
 import plotly.express as px  # type: ignore
 from dash import Input, Output, callback, dcc, html  # type: ignore
-from dash.exceptions import PreventUpdate  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
-from .. import LIVE_MODEL, log
-from ..datahub_api import get_opal_data
 from ..figures import (
     generate_balancing_market_fig,
     generate_intraday_market_sys_fig,
@@ -25,10 +22,6 @@ from ..figures import (
 )
 
 dash.register_page(__name__)
-
-##################
-interval = 7000
-##################
 
 df = pd.DataFrame({"Col": [0]})
 
@@ -102,7 +95,6 @@ layout = html.Div(
                 ),
             ],
         ),
-        dcc.Interval(id="interval", interval=interval),
     ],
 )
 
@@ -114,35 +106,25 @@ layout = html.Div(
         Output("intraday_market_sys_fig", "figure"),
         Output("reserve_generation_fig", "figure"),
     ],
-    [Input("interval", "n_intervals")],
+    [Input("data_opal", "data")],
 )
-def update_data(n_intervals: int) -> tuple[go.Figure, go.Figure, go.Figure, px.line]:
+def update_figures(
+    data_opal: list[dict[str, object]],
+) -> tuple[go.Figure, go.Figure, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+        data_opal (list): Opal data
 
     Returns:
         tuple[go.Figure, go.Figure, go.Figure, px.line]: The new figures.
     """
-    if n_intervals is None:
-        raise PreventUpdate
+    df_opal = pd.DataFrame(data_opal)
 
-    if LIVE_MODEL:
-        log.debug("Updating plots from live model")
-        data = get_opal_data()
-        new_df = pd.DataFrame(**data)  # type: ignore[call-overload]
-    else:
-        from ..pre_set_data import OPAL_DATA
-
-        log.debug("Updating plots with pre-set data")
-        new_df = OPAL_DATA.loc[:n_intervals]
-
-    weather_fig = generate_weather_fig(new_df)
-    balancing_market_fig = generate_balancing_market_fig(new_df)
-    intraday_market_sys_fig = generate_intraday_market_sys_fig(new_df)
-    reserve_generation_fig = generate_reserve_generation_fig(new_df)
+    weather_fig = generate_weather_fig(df_opal)
+    balancing_market_fig = generate_balancing_market_fig(df_opal)
+    intraday_market_sys_fig = generate_intraday_market_sys_fig(df_opal)
+    reserve_generation_fig = generate_reserve_generation_fig(df_opal)
     return (
         weather_fig,
         balancing_market_fig,

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -106,25 +106,26 @@ layout = html.Div(
         Output("intraday_market_sys_fig", "figure"),
         Output("reserve_generation_fig", "figure"),
     ],
-    [Input("data_opal", "data")],
+    [Input("figure_interval", "n_intervals")],
 )
 def update_figures(
-    data_opal: list[dict[str, object]],
+    n_intervals: int,
 ) -> tuple[go.Figure, go.Figure, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        data_opal (list): Opal data
+        n_intervals (int): The number of times this page has updated.
+            indexes by 1 every 7 seconds.
 
     Returns:
         tuple[go.Figure, go.Figure, go.Figure, px.line]: The new figures.
     """
-    df_opal = pd.DataFrame(data_opal)
+    from ..data import DF_OPAL
 
-    weather_fig = generate_weather_fig(df_opal)
-    balancing_market_fig = generate_balancing_market_fig(df_opal)
-    intraday_market_sys_fig = generate_intraday_market_sys_fig(df_opal)
-    reserve_generation_fig = generate_reserve_generation_fig(df_opal)
+    weather_fig = generate_weather_fig(DF_OPAL)
+    balancing_market_fig = generate_balancing_market_fig(DF_OPAL)
+    intraday_market_sys_fig = generate_intraday_market_sys_fig(DF_OPAL)
+    reserve_generation_fig = generate_reserve_generation_fig(DF_OPAL)
     return (
         weather_fig,
         balancing_market_fig,

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -12,10 +12,7 @@ import dash  # type: ignore
 import pandas as pd
 import plotly.express as px  # type: ignore
 from dash import Input, Output, callback, dcc, html  # type: ignore
-from dash.exceptions import PreventUpdate  # type: ignore
 
-from .. import LIVE_MODEL, log
-from ..datahub_api import get_opal_data
 from ..figures import (
     generate_gen_split_fig,
     generate_system_freq_fig,
@@ -24,10 +21,6 @@ from ..figures import (
 )
 
 dash.register_page(__name__)
-
-##################
-interval = 7000
-##################
 
 df = pd.DataFrame({"Col": [0]})
 
@@ -97,7 +90,6 @@ layout = html.Div(
                 ),
             ],
         ),
-        dcc.Interval(id="interval", interval=interval),
     ],
 )
 
@@ -109,33 +101,23 @@ layout = html.Div(
         Output("graph-demand", "figure"),
         Output("graph-freq", "figure"),
     ],
-    [Input("interval", "n_intervals")],
+    [Input("data_opal", "data")],
 )
-def update_data(n_intervals: int) -> tuple[px.pie, px.line, px.line, px.line]:
+def update_figures(
+    data_opal: list[dict[str, object]],
+) -> tuple[px.pie, px.line, px.line, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+        data_opal (list): Opal data
 
     Returns:
         tuple[px.pie, px.line, px.line, px.line]: The new figures.
     """
-    if n_intervals is None:
-        raise PreventUpdate
+    df_opal = pd.DataFrame(data_opal)
 
-    if LIVE_MODEL:
-        log.debug("Updating plots from live model")
-        data = get_opal_data()
-        new_df = pd.DataFrame(**data)  # type: ignore[call-overload]
-    else:
-        from ..pre_set_data import OPAL_DATA
-
-        log.debug("Updating plots with pre-set data")
-        new_df = OPAL_DATA.loc[:n_intervals]
-
-    gen_split_fig = generate_gen_split_fig(new_df)
-    total_gen_fig = generate_total_gen_fig(new_df)
-    total_dem_fig = generate_total_dem_fig(new_df)
-    system_freq_fig = generate_system_freq_fig(new_df)
+    gen_split_fig = generate_gen_split_fig(df_opal)
+    total_gen_fig = generate_total_gen_fig(df_opal)
+    total_dem_fig = generate_total_dem_fig(df_opal)
+    system_freq_fig = generate_system_freq_fig(df_opal)
     return gen_split_fig, total_gen_fig, total_dem_fig, system_freq_fig

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -101,23 +101,24 @@ layout = html.Div(
         Output("graph-demand", "figure"),
         Output("graph-freq", "figure"),
     ],
-    [Input("data_opal", "data")],
+    [Input("figure_interval", "n_intervals")],
 )
 def update_figures(
-    data_opal: list[dict[str, object]],
+    n_intervals: int,
 ) -> tuple[px.pie, px.line, px.line, px.line]:
     """Function to update the plots in this page.
 
     Args:
-        data_opal (list): Opal data
+        n_intervals (int): The number of times this page has updated.
+            indexes by 1 every 7 seconds.
 
     Returns:
         tuple[px.pie, px.line, px.line, px.line]: The new figures.
     """
-    df_opal = pd.DataFrame(data_opal)
+    from ..data import DF_OPAL
 
-    gen_split_fig = generate_gen_split_fig(df_opal)
-    total_gen_fig = generate_total_gen_fig(df_opal)
-    total_dem_fig = generate_total_dem_fig(df_opal)
-    system_freq_fig = generate_system_freq_fig(df_opal)
+    gen_split_fig = generate_gen_split_fig(DF_OPAL)
+    total_gen_fig = generate_total_gen_fig(DF_OPAL)
+    total_dem_fig = generate_total_dem_fig(DF_OPAL)
+    system_freq_fig = generate_system_freq_fig(DF_OPAL)
     return gen_split_fig, total_gen_fig, total_dem_fig, system_freq_fig


### PR DESCRIPTION
# Description

This abstracts the datahub calls into a new data module. The control page is responsible for communicating with the data module and periodically updating the data (therefore the control page must be open for the data to update). The figure pages are set to periodically import the data and update (controlled by a different interval).

A couple more things in the issue which I haven't addressed yet:
- stopping updates after data is complete
- updating only the data component of the figures

Close #67 

To merge after #75

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [x] Pre-commit hooks run successfully (`pre-commit run --all-files`)
