### PR TITLE
Connect restart button to refresh API call

### DIFF
--- a/app/core_api.py
+++ b/app/core_api.py
@@ -88,6 +88,11 @@ def assign_sections(new_sections: dict[str, str]) -> None:
                 log.error(f"Could not set view for {space} to {new_sections[space]}")
 
 
+def refresh_sections() -> None:
+    """Refresh all the sections."""
+    requests.post(f"{API_URL}/sections/refresh")
+
+
 def move_section(id_num: int, space: str) -> None:
     """Function to move a section by ID to a specified space.
 

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -284,6 +284,7 @@ def update_button_click(
     elif button_id == "restart":
         """Will make an API call to restart the Gridlington simulation and Datahub."""
         log.debug("Clicked Restart Button!")
+        core.refresh_sections()
         return ["Clicked Restart Button!"]
 
     else:

--- a/tests/test_control_view.py
+++ b/tests/test_control_view.py
@@ -69,5 +69,7 @@ def test_control_view_callback(mocker):
     button_id = "button_restart"
 
     ctx = copy_context()
+    patched_refresh_sections = mocker.patch("app.core_api.refresh_sections")
     output = ctx.run(run_callback)
+    patched_refresh_sections.assert_called_once()
     assert output[0] == "Clicked Restart Button!"


### PR DESCRIPTION
# Description

This uses the refresh OVE call that restarts all of the views. This will restart pre-set data simulation, but to get the equivalent behaviour for the full models requires more thought

Close #65 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (`python -m pytest`)
- [ ] Pre-commit hooks run successfully (`pre-commit run --all-files`)
