### PR TITLE
Move titles to graphs

### DIFF
--- a/app/figures.py
+++ b/app/figures.py
@@ -13,7 +13,7 @@ time_range = ["2035-01-22 00:00:00", "2035-01-22 00:07:01.140"]
 
 
 def figure(title: str, title_size: float | int = 30) -> Callable:  # type:ignore
-    """Decorator for modifying figures.
+    """Decorator for common formatting of all figures.
 
     Args:
         title (str): Title
@@ -40,7 +40,7 @@ def figure(title: str, title_size: float | int = 30) -> Callable:  # type:ignore
 
 
 def line_graph(func: Callable) -> Callable:  # type:ignore
-    """Decorator to format time-series line graphs.
+    """Decorator for common formatting of time-series line graphs.
 
     Args:
         func (Callable): Line graph function

--- a/app/figures.py
+++ b/app/figures.py
@@ -617,6 +617,7 @@ def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     return ev_charging_breakdown_fig
 
 
+@figure("Weather")
 def generate_weather_fig(wesim_data: dict[str, pd.DataFrame]) -> go.Figure:
     """Creates plotly figure for Weather table.
 
@@ -693,6 +694,8 @@ def generate_weather_fig(wesim_data: dict[str, pd.DataFrame]) -> go.Figure:
     return weather_fig
 
 
+@figure("Reserve/Standby Generation")
+@axes(ylabel="MW", yrange=[25000, 35000])
 def generate_reserve_generation_fig(wesim_data: dict[str, pd.DataFrame]) -> go.Figure:
     """Creates Plotly figure for Reserve/Standby Generation graph.
 
@@ -720,9 +723,5 @@ def generate_reserve_generation_fig(wesim_data: dict[str, pd.DataFrame]) -> go.F
             wesim_regions_total,
             x="Time",
             y="Solar Reserve",
-            range_x=time_range,
-        ).update_layout(
-            yaxis_title="MW",
-        )  # TODO: check units
-
+        )
     return reserve_generation_fig

--- a/app/figures.py
+++ b/app/figures.py
@@ -278,6 +278,9 @@ def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
             intraday_market_sys_fig_left.data + intraday_market_sys_fig_right.data
         )
 
+    intraday_market_sys_fig.layout.xaxis.title = "Time"
+    intraday_market_sys_fig.layout.xaxis.range = time_range
+    intraday_market_sys_fig.update_xaxes(type="date")
     intraday_market_sys_fig.layout.yaxis.title = "MW"
     intraday_market_sys_fig.layout.yaxis2.title = "£/MW"
     intraday_market_sys_fig.layout.yaxis.range = [-100, 100]
@@ -330,6 +333,9 @@ def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
             balancing_market_fig_left.data + balancing_market_fig_right.data
         )
 
+    balancing_market_fig.layout.xaxis.title = "Time"
+    balancing_market_fig.layout.xaxis.range = time_range
+    balancing_market_fig.update_xaxes(type="date")
     balancing_market_fig.layout.yaxis.title = "MW"
     balancing_market_fig.layout.yaxis2.title = "£/MW"
     balancing_market_fig.layout.yaxis.range = [-250, 250]
@@ -430,6 +436,9 @@ def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
 
         dsr_fig.add_traces(dsr_fig_left.data + dsr_fig_right.data)
 
+    dsr_fig.layout.xaxis.title = "Time"
+    dsr_fig.layout.xaxis.range = time_range
+    dsr_fig.update_xaxes(type="date")
     dsr_fig.layout.yaxis.title = "kW"
     dsr_fig.layout.yaxis2.title = "£/MW"
     dsr_fig.layout.yaxis.range = [-1, 1]  # TODO: Check range

--- a/app/figures.py
+++ b/app/figures.py
@@ -44,6 +44,8 @@ def axes(
     yrange: list[str | float],
     xlabel: str = "Time",
     xrange: list[str | float] = time_range,  # type:ignore
+    xdomain: list[float] = [0, 1],
+    ydomain: list[float] = [0, 1],
 ) -> Callable:  # type: ignore[type-arg]
     """Decorator to set axis labels and ranges.
 
@@ -53,6 +55,10 @@ def axes(
         xlabel (str, optional): X axis label. Defaults to "Time".
         xrange (list[str  |  float], optional): X-axis range.
             Defaults to time_range.
+        xdomain (list[float], optional): Region of figure width occupied by
+            the x-axis. Defaults to [0, 1].
+        ydomain (list[float], optional): Region of figure height occupied by
+            the y-axis. Defaults to [0, 1].
 
     Returns:
         Callable: Decorated function
@@ -68,6 +74,7 @@ def axes(
                 fig.update_xaxes(type="date")
             fig.layout.yaxis.title = ylabel
             fig.layout.yaxis.range = yrange
+            fig.update_layout(xaxis=dict(domain=xdomain), yaxis=dict(domain=ydomain))
             return fig
 
         return wrapper

--- a/app/figures.py
+++ b/app/figures.py
@@ -82,12 +82,18 @@ def axes(
     return decorator
 
 
-def timestamp(x: float = 0, y: float = 1) -> Callable:  # type: ignore[type-arg]
+def timestamp(
+    x: float = 0, y: float = 1, fontsize: float = 14, color: str = "black"
+) -> Callable:  # type: ignore[type-arg]
     """Decorator to add timestamp to figure.
+
+    Coordinate scheme: x=0, y=1 corresponds to top left
 
     Args:
         x (float, optional): x coordinate of the timestamp. Defaults to 0.
         y (float, optional): y coordinate of the timestamp. Defaults to 1.
+        fontsize (float, optional): font size
+        color (str, optional): text color
 
     Returns:
         Callable: Decorated function
@@ -105,8 +111,10 @@ def timestamp(x: float = 0, y: float = 1) -> Callable:  # type: ignore[type-arg]
                             text=df.iloc[-1]["Time"],
                             x=x,
                             y=y,
+                            xref="paper",
+                            yref="paper",
                             showarrow=False,
-                            font=dict(size=14, color="black"),
+                            font=dict(size=fontsize, color=color),
                         )
                     ]
                 )

--- a/app/figures.py
+++ b/app/figures.py
@@ -12,7 +12,7 @@ from plotly.subplots import make_subplots  # type: ignore
 time_range = ["2035-01-22 04:00", "2035-01-22 11:00"]
 
 
-def figure(title: str, title_size: float = 30) -> Callable:  # type:ignore
+def figure(title: str, title_size: float = 30) -> Callable:  # type: ignore[type-arg]
     """Decorator for common formatting of all figures.
 
     Args:
@@ -23,7 +23,7 @@ def figure(title: str, title_size: float = 30) -> Callable:  # type:ignore
         Callable: Decorated function
     """
 
-    def decorator(func: Callable) -> Callable:  # type:ignore
+    def decorator(func: Callable) -> Callable:  # type: ignore[type-arg]
         @wraps(func)
         def wrapper(df: pd.DataFrame) -> Union[px.pie, px.line, go.Figure]:
             fig = func(df)
@@ -44,7 +44,7 @@ def axes(
     yrange: list[str | float],
     xlabel: str = "Time",
     xrange: list[str | float] = time_range,  # type:ignore
-) -> Callable:  # type:ignore
+) -> Callable:  # type: ignore[type-arg]
     """Decorator to set axis labels and ranges.
 
     Args:
@@ -58,7 +58,7 @@ def axes(
         Callable: Decorated function
     """
 
-    def decorator(func: Callable) -> Callable:  # type:ignore
+    def decorator(func: Callable) -> Callable:  # type: ignore[type-arg]
         @wraps(func)
         def wrapper(df: pd.DataFrame) -> Union[px.pie, px.line, go.Figure]:
             fig = func(df)
@@ -75,7 +75,7 @@ def axes(
     return decorator
 
 
-def timestamp(x: float = 0, y: float = 1) -> Callable:  # type:ignore
+def timestamp(x: float = 0, y: float = 1) -> Callable:  # type: ignore[type-arg]
     """Decorator to add timestamp to figure.
 
     Args:
@@ -86,7 +86,7 @@ def timestamp(x: float = 0, y: float = 1) -> Callable:  # type:ignore
         Callable: Decorated function
     """
 
-    def decorator(func: Callable) -> Callable:  # type:ignore
+    def decorator(func: Callable) -> Callable:  # type: ignore[type-arg]
         @wraps(func)
         def wrapper(df: pd.DataFrame) -> Union[px.pie, px.line, go.Figure]:
             fig = func(df)

--- a/app/figures.py
+++ b/app/figures.py
@@ -75,7 +75,44 @@ def axes(
     return decorator
 
 
+def timestamp(x: float = 0, y: float = 1) -> Callable:  # type:ignore
+    """Decorator to add timestamp to figure.
+
+    Args:
+        x (float, optional): x coordinate of the timestamp. Defaults to 0.
+        y (float, optional): y coordinate of the timestamp. Defaults to 1.
+
+    Returns:
+        Callable: Decorated function
+    """
+
+    def decorator(func: Callable) -> Callable:  # type:ignore
+        @wraps(func)
+        def wrapper(df: pd.DataFrame) -> Union[px.pie, px.line, go.Figure]:
+            fig = func(df)
+
+            if not len(df.columns) == 1:
+                fig.update_layout(
+                    annotations=[
+                        dict(
+                            text=df.iloc[-1]["Time"],
+                            x=x,
+                            y=y,
+                            showarrow=False,
+                            font=dict(size=14, color="black"),
+                        )
+                    ]
+                )
+
+            return fig
+
+        return wrapper
+
+    return decorator
+
+
 @figure("Generation Split")
+@timestamp()
 def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
     """Creates Plotly figure for Generation Split graph.
 
@@ -105,7 +142,6 @@ def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
             values=gen_split_df,
         )
 
-    # title_text=df.iloc[-1]["Time"],
     return gen_split_fig
 
 
@@ -528,6 +564,7 @@ def create_waffle_chart(
 
 
 @figure("Agent Activity Breakdown")
+@timestamp()
 def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for agent activity breakdown figure.
 
@@ -551,11 +588,11 @@ def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     agent_activity_breakdown_fig.update_layout(
         legend_title_text="Household Activity",
     )
-    # title_text=df.iloc[-1]["Time"]
     return agent_activity_breakdown_fig
 
 
 @figure("Electric Vehicle Charging Breakdown")
+@timestamp()
 def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for EV charging breakdown figure.
 
@@ -577,7 +614,6 @@ def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     ev_charging_breakdown_fig.update_layout(
         legend_title_text="EV Status",
     )
-    # title_text=df.iloc[-1]["Time"]
     return ev_charging_breakdown_fig
 
 

--- a/app/figures.py
+++ b/app/figures.py
@@ -1,4 +1,7 @@
 """Functions for generating plotly figures."""
+from functools import wraps
+from typing import Callable, Union
+
 import numpy as np
 import pandas as pd
 import plotly.express as px  # type: ignore
@@ -7,9 +10,36 @@ from plotly.colors import DEFAULT_PLOTLY_COLORS  # type: ignore
 from plotly.subplots import make_subplots  # type: ignore
 
 time_range = ["2035-01-22 00:00:00", "2035-01-22 00:07:01.140"]
-title_size = 30
 
 
+def figure(title: str, title_size: float | int = 30) -> Callable:  # type:ignore
+    """Decorator for modifying figures.
+
+    Args:
+        title (str): Title
+        title_size (float | int, optional): Title size. Defaults to 30.
+
+    Returns:
+        Callable: Decorated function
+    """
+
+    def decorator(func: Callable) -> Callable:  # type:ignore
+        @wraps(func)
+        def wrapper(df: pd.DataFrame) -> Union[px.pie, px.line, go.Figure]:
+            fig = func(df)
+            fig.update_layout(
+                title_text=title,
+                title={"font": {"size": title_size}},
+                title_x=0.5,
+            )
+            return fig
+
+        return wrapper
+
+    return decorator
+
+
+@figure("Generation Split")
 def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
     """Creates Plotly figure for Generation Split graph.
 
@@ -39,15 +69,11 @@ def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
             values=gen_split_df,
         )
 
-    gen_split_fig.update_layout(
-        title_text="Generation Split",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
-    )
     # title_text=df.iloc[-1]["Time"],
     return gen_split_fig
 
 
+@figure("Generation Total")
 def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Total Generation graph.
 
@@ -80,9 +106,6 @@ def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
 
     total_gen_fig.update_layout(
         yaxis_title="GW",
-        title_text="Generation Total",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     total_gen_fig.layout.xaxis.title = "Time"
     total_gen_fig.layout.xaxis.range = time_range
@@ -92,6 +115,7 @@ def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
     return total_gen_fig
 
 
+@figure("Demand Total")
 def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Total Demand graph.
 
@@ -113,9 +137,6 @@ def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
         )
     total_dem_fig.update_layout(
         yaxis_title="GW",
-        title_text="Demand Total",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     total_dem_fig.layout.xaxis.title = "Time"
     total_dem_fig.layout.xaxis.range = time_range
@@ -124,6 +145,7 @@ def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
     return total_dem_fig
 
 
+@figure("System Frequency")
 def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for System Frequency graph.
 
@@ -146,9 +168,6 @@ def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
         )
     system_freq_fig.update_layout(
         yaxis_title="GW",
-        title_text="System Frequency",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     system_freq_fig.layout.xaxis.title = "Time"
     system_freq_fig.layout.xaxis.range = time_range
@@ -158,6 +177,7 @@ def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
     return system_freq_fig
 
 
+@figure("Intra-day Market System")
 def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
     """Creates Plotly figure for Intra-day Market System graph.
 
@@ -207,15 +227,12 @@ def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
     intraday_market_sys_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
-    intraday_market_sys_fig.update_layout(
-        title={"text": "Intra-day Market System", "font": {"size": title_size}},
-        title_x=0.5,
-    )
     intraday_market_sys_fig.update_xaxes(type="date")
 
     return intraday_market_sys_fig
 
 
+@figure("Balancing Market")
 def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
     """Creates Plotly figure for Balancing Market graph.
 
@@ -265,15 +282,12 @@ def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
     balancing_market_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
-    balancing_market_fig.update_layout(
-        title={"text": "Balancing Market", "font": {"size": title_size}},
-        title_x=0.5,
-    )
     balancing_market_fig.update_xaxes(type="date")
 
     return balancing_market_fig
 
 
+@figure("Energy Deficit")
 def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Energy Deficit graph.
 
@@ -294,9 +308,6 @@ def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
 
     energy_deficit_fig.update_layout(
         yaxis_title="MW",
-        title_text="Energy Deficit",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     energy_deficit_fig.layout.xaxis.title = "Time"
     energy_deficit_fig.layout.xaxis.range = time_range
@@ -305,6 +316,7 @@ def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
     return energy_deficit_fig
 
 
+@figure("Intraday Market Bids and Offers")
 def generate_intraday_market_bids_fig(df: pd.DataFrame) -> go.Figure:
     """Creates plotly Figure object for Intraday Market Bids and Offers table.
 
@@ -329,16 +341,10 @@ def generate_intraday_market_bids_fig(df: pd.DataFrame) -> go.Figure:
             ]
         )
 
-    intraday_market_bids_fig.update_layout(
-        title={
-            "text": "Intraday Market Bids and Offers",
-            "font": {"size": title_size},
-        },
-        title_x=0.5,
-    )
     return intraday_market_bids_fig
 
 
+@figure("Demand Side Response")
 def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
     """Creates plotly figure for Demand Side Response graph.
 
@@ -383,14 +389,11 @@ def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
     dsr_fig.layout.yaxis.range = [-1, 1]  # TODO: Check range
     dsr_fig.layout.yaxis2.range = [-1, 1]
     dsr_fig.for_each_trace(lambda t: t.update(line=dict(color=t.marker.color)))
-    dsr_fig.update_layout(
-        title={"text": "Demand Side Response", "font": {"size": title_size}},
-        title_x=0.5,
-    )
     dsr_fig.update_xaxes(type="date")
     return dsr_fig
 
 
+@figure("DSR Commands to Agents")
 def generate_dsr_commands_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for DSR Commands to Agents graph.
 
@@ -426,9 +429,6 @@ def generate_dsr_commands_fig(df: pd.DataFrame) -> px.line:
     dsr_commands_fig.update_layout(
         yaxis_title="MW",
         legend_title=None,
-        title_text="DSR Commands to Agents",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     dsr_commands_fig.layout.xaxis.title = "Time"
     dsr_commands_fig.layout.xaxis.range = time_range
@@ -529,6 +529,7 @@ def create_waffle_chart(
     return waffle
 
 
+@figure("Agent Activity Breakdown")
 def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for agent activity breakdown figure.
 
@@ -551,14 +552,12 @@ def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
         )
     agent_activity_breakdown_fig.update_layout(
         legend_title_text="Household Activity",
-        title_text="Agent Activity Breakdown",
-        title={"font": {"size": title_size}},
-        title_x=0.5,
     )
     # title_text=df.iloc[-1]["Time"]
     return agent_activity_breakdown_fig
 
 
+@figure("Electric Vehicle Charging Breakdown")
 def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for EV charging breakdown figure.
 
@@ -579,11 +578,6 @@ def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
         )
     ev_charging_breakdown_fig.update_layout(
         legend_title_text="EV Status",
-        title_text="Electric Vehicle Charging Breakdown",
-        title={
-            "font": {"size": title_size},
-        },
-        title_x=0.5,
     )
     # title_text=df.iloc[-1]["Time"]
     return ev_charging_breakdown_fig

--- a/app/figures.py
+++ b/app/figures.py
@@ -7,6 +7,7 @@ from plotly.colors import DEFAULT_PLOTLY_COLORS  # type: ignore
 from plotly.subplots import make_subplots  # type: ignore
 
 time_range = ["2035-01-22 00:00:00", "2035-01-22 00:07:01.140"]
+title_size = 30
 
 
 def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
@@ -22,7 +23,6 @@ def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
         gen_split_fig = px.pie()
     else:
         gen_split_df = df.iloc[-1, 13:23]
-
         gen_split_fig = px.pie(
             names=[
                 "Battery Generation",
@@ -37,7 +37,14 @@ def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
                 "Gas Generation",
             ],
             values=gen_split_df,
-        ).update_layout(title_text=df.iloc[-1]["Time"])
+        )
+
+    gen_split_fig.update_layout(
+        title_text="Generation Split",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    # title_text=df.iloc[-1]["Time"],
     return gen_split_fig
 
 
@@ -69,9 +76,19 @@ def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
                 "Hydro Generation",
                 "Gas Generation",
             ],
-            range_x=time_range,
-            range_y=[-5, 70],
-        ).update_layout(yaxis_title="GW")
+        )
+
+    total_gen_fig.update_layout(
+        yaxis_title="GW",
+        title_text="Generation Total",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    total_gen_fig.layout.xaxis.title = "Time"
+    total_gen_fig.layout.xaxis.range = time_range
+    total_gen_fig.layout.yaxis.range = [-5, 70]
+    total_gen_fig.update_xaxes(type="date")
+
     return total_gen_fig
 
 
@@ -93,9 +110,17 @@ def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
             y=[
                 "Total Demand",
             ],
-            range_x=time_range,
-            range_y=[-5, 70],
-        ).update_layout(yaxis_title="GW")
+        )
+    total_dem_fig.update_layout(
+        yaxis_title="GW",
+        title_text="Demand Total",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    total_dem_fig.layout.xaxis.title = "Time"
+    total_dem_fig.layout.xaxis.range = time_range
+    total_dem_fig.layout.yaxis.range = [-5, 70]
+    total_dem_fig.update_xaxes(type="date")
     return total_dem_fig
 
 
@@ -118,9 +143,18 @@ def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
                 "Total Generation",
                 "Total Demand",
             ],
-            range_x=time_range,
-            range_y=[-5, 70],
-        ).update_layout(yaxis_title="GW")
+        )
+    system_freq_fig.update_layout(
+        yaxis_title="GW",
+        title_text="System Frequency",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    system_freq_fig.layout.xaxis.title = "Time"
+    system_freq_fig.layout.xaxis.range = time_range
+    system_freq_fig.layout.yaxis.range = [-5, 70]
+    system_freq_fig.update_xaxes(type="date")
+
     return system_freq_fig
 
 
@@ -135,36 +169,35 @@ def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
     """
     intraday_market_sys_fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    if len(df.columns) == 1:
-        return intraday_market_sys_fig
-
-    left_axis_columns = [
-        "Intra-Day Market Generation",
-        "Intra-Day Market Storage",
-        "Intra-Day Market Demand",
-    ]
-    intraday_market_sys_fig_left = px.line(
-        df,
-        x="Time",
-        y=left_axis_columns,
-    ).for_each_trace(lambda t: t.update(name=t.name + " (MW)"))
-
-    right_axis_columns = [
-        "Intra-Day Market Value",
-    ]
-    intraday_market_sys_fig_right = (
-        px.line(
+    if not len(df.columns) == 1:
+        left_axis_columns = [
+            "Intra-Day Market Generation",
+            "Intra-Day Market Storage",
+            "Intra-Day Market Demand",
+        ]
+        intraday_market_sys_fig_left = px.line(
             df,
             x="Time",
-            y=right_axis_columns,
-        )
-        .update_traces(yaxis="y2")
-        .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
-    )
+            y=left_axis_columns,
+        ).for_each_trace(lambda t: t.update(name=t.name + " (MW)"))
 
-    intraday_market_sys_fig.add_traces(
-        intraday_market_sys_fig_left.data + intraday_market_sys_fig_right.data
-    )
+        right_axis_columns = [
+            "Intra-Day Market Value",
+        ]
+        intraday_market_sys_fig_right = (
+            px.line(
+                df,
+                x="Time",
+                y=right_axis_columns,
+            )
+            .update_traces(yaxis="y2")
+            .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
+        )
+
+        intraday_market_sys_fig.add_traces(
+            intraday_market_sys_fig_left.data + intraday_market_sys_fig_right.data
+        )
+
     intraday_market_sys_fig.layout.xaxis.title = "Time"
     intraday_market_sys_fig.layout.yaxis.title = "MW"
     intraday_market_sys_fig.layout.yaxis2.title = "£/MW"
@@ -174,6 +207,11 @@ def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
     intraday_market_sys_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
+    intraday_market_sys_fig.update_layout(
+        title={"text": "Intra-day Market System", "font": {"size": title_size}},
+        title_x=0.5,
+    )
+    intraday_market_sys_fig.update_xaxes(type="date")
 
     return intraday_market_sys_fig
 
@@ -189,36 +227,35 @@ def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
     """
     balancing_market_fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    if len(df.columns) == 1:
-        return balancing_market_fig
-
-    left_axis_columns = [
-        "Balancing Mechanism Generation",
-        "Balancing Mechanism Storage",
-        "Balancing Mechanism Demand",
-    ]
-    balancing_market_fig_left = px.line(
-        df,
-        x="Time",
-        y=left_axis_columns,
-    ).for_each_trace(lambda t: t.update(name=t.name + " (MW)"))
-
-    right_axis_columns = [
-        "Balancing Mechanism Value",
-    ]
-    balancing_market_fig_right = (
-        px.line(
+    if not len(df.columns) == 1:
+        left_axis_columns = [
+            "Balancing Mechanism Generation",
+            "Balancing Mechanism Storage",
+            "Balancing Mechanism Demand",
+        ]
+        balancing_market_fig_left = px.line(
             df,
             x="Time",
-            y=right_axis_columns,
-        )
-        .update_traces(yaxis="y2")
-        .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
-    )
+            y=left_axis_columns,
+        ).for_each_trace(lambda t: t.update(name=t.name + " (MW)"))
 
-    balancing_market_fig.add_traces(
-        balancing_market_fig_left.data + balancing_market_fig_right.data
-    )
+        right_axis_columns = [
+            "Balancing Mechanism Value",
+        ]
+        balancing_market_fig_right = (
+            px.line(
+                df,
+                x="Time",
+                y=right_axis_columns,
+            )
+            .update_traces(yaxis="y2")
+            .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
+        )
+
+        balancing_market_fig.add_traces(
+            balancing_market_fig_left.data + balancing_market_fig_right.data
+        )
+
     balancing_market_fig.layout.xaxis.title = "Time"
     balancing_market_fig.layout.yaxis.title = "MW"
     balancing_market_fig.layout.yaxis2.title = "£/MW"
@@ -228,6 +265,11 @@ def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
     balancing_market_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
+    balancing_market_fig.update_layout(
+        title={"text": "Balancing Market", "font": {"size": title_size}},
+        title_x=0.5,
+    )
+    balancing_market_fig.update_xaxes(type="date")
 
     return balancing_market_fig
 
@@ -248,10 +290,18 @@ def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
             df,
             x="Time",
             y=df["Exp. Offshore Wind Generation"] - df["Real Offshore Wind Generation"],
-            range_y=[-600, 600],
-            range_x=time_range,
-        ).update_layout(yaxis_title="MW")
+        )
 
+    energy_deficit_fig.update_layout(
+        yaxis_title="MW",
+        title_text="Energy Deficit",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    energy_deficit_fig.layout.xaxis.title = "Time"
+    energy_deficit_fig.layout.xaxis.range = time_range
+    energy_deficit_fig.layout.yaxis.range = [-600, 600]
+    energy_deficit_fig.update_xaxes(type="date")
     return energy_deficit_fig
 
 
@@ -279,6 +329,13 @@ def generate_intraday_market_bids_fig(df: pd.DataFrame) -> go.Figure:
             ]
         )
 
+    intraday_market_bids_fig.update_layout(
+        title={
+            "text": "Intraday Market Bids and Offers",
+            "font": {"size": title_size},
+        },
+        title_x=0.5,
+    )
     return intraday_market_bids_fig
 
 
@@ -293,33 +350,32 @@ def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
     """
     dsr_fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    if len(df.columns) == 1:
-        return dsr_fig
-
-    left_axis_columns = [
-        "Cost",  # TODO: This will need to be changed when data is available
-        "Cost",  # TODO: As above
-    ]
-    dsr_fig_left = px.line(
-        df,
-        x="Time",
-        y=left_axis_columns,
-    ).for_each_trace(lambda t: t.update(name=t.name + " (kW)"))
-
-    right_axis_columns = [
-        "Cost",
-    ]
-    dsr_fig_right = (
-        px.line(
+    if not len(df.columns) == 1:
+        left_axis_columns = [
+            "Cost",  # TODO: This will need to be changed when data is available
+            "Cost",  # TODO: As above
+        ]
+        dsr_fig_left = px.line(
             df,
             x="Time",
-            y=right_axis_columns,
-        )
-        .update_traces(yaxis="y2")
-        .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
-    )
+            y=left_axis_columns,
+        ).for_each_trace(lambda t: t.update(name=t.name + " (kW)"))
 
-    dsr_fig.add_traces(dsr_fig_left.data + dsr_fig_right.data)
+        right_axis_columns = [
+            "Cost",
+        ]
+        dsr_fig_right = (
+            px.line(
+                df,
+                x="Time",
+                y=right_axis_columns,
+            )
+            .update_traces(yaxis="y2")
+            .for_each_trace(lambda t: t.update(name=t.name + " (£/MW)"))
+        )
+
+        dsr_fig.add_traces(dsr_fig_left.data + dsr_fig_right.data)
+
     dsr_fig.layout.xaxis.title = "Time"  # TODO: Check units
     dsr_fig.layout.yaxis.title = "kW"
     dsr_fig.layout.yaxis2.title = "£/MW"
@@ -327,7 +383,11 @@ def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
     dsr_fig.layout.yaxis.range = [-1, 1]  # TODO: Check range
     dsr_fig.layout.yaxis2.range = [-1, 1]
     dsr_fig.for_each_trace(lambda t: t.update(line=dict(color=t.marker.color)))
-
+    dsr_fig.update_layout(
+        title={"text": "Demand Side Response", "font": {"size": title_size}},
+        title_x=0.5,
+    )
+    dsr_fig.update_xaxes(type="date")
     return dsr_fig
 
 
@@ -361,10 +421,19 @@ def generate_dsr_commands_fig(df: pd.DataFrame) -> px.line:
                 "Name",
                 "Name2",
             ],
-            range_y=[-8, 8],
-            range_x=time_range,
-        ).update_layout(yaxis_title="MW", legend_title=None)
+        )
 
+    dsr_commands_fig.update_layout(
+        yaxis_title="MW",
+        legend_title=None,
+        title_text="DSR Commands to Agents",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    dsr_commands_fig.layout.xaxis.title = "Time"
+    dsr_commands_fig.layout.xaxis.range = time_range
+    dsr_commands_fig.layout.yaxis.range = [-8, 8]
+    dsr_commands_fig.update_xaxes(type="date")
     return dsr_commands_fig
 
 
@@ -480,9 +549,13 @@ def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
         agent_activity_breakdown_fig = create_waffle_chart(
             categories=categories, counts=counts, gap=1
         )
-        agent_activity_breakdown_fig.update_layout(
-            legend_title_text="Household Activity", title_text=df.iloc[-1]["Time"]
-        )
+    agent_activity_breakdown_fig.update_layout(
+        legend_title_text="Household Activity",
+        title_text="Agent Activity Breakdown",
+        title={"font": {"size": title_size}},
+        title_x=0.5,
+    )
+    # title_text=df.iloc[-1]["Time"]
     return agent_activity_breakdown_fig
 
 
@@ -504,9 +577,15 @@ def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
         ev_charging_breakdown_fig = create_waffle_chart(
             categories=categories, counts=counts, gap=1
         )
-        ev_charging_breakdown_fig.update_layout(
-            legend_title_text="EV Status", title_text=df.iloc[-1]["Time"]
-        )
+    ev_charging_breakdown_fig.update_layout(
+        legend_title_text="EV Status",
+        title_text="Electric Vehicle Charging Breakdown",
+        title={
+            "font": {"size": title_size},
+        },
+        title_x=0.5,
+    )
+    # title_text=df.iloc[-1]["Time"]
     return ev_charging_breakdown_fig
 
 

--- a/app/figures.py
+++ b/app/figures.py
@@ -39,6 +39,26 @@ def figure(title: str, title_size: float | int = 30) -> Callable:  # type:ignore
     return decorator
 
 
+def line_graph(func: Callable) -> Callable:  # type:ignore
+    """Decorator to format time-series line graphs.
+
+    Args:
+        func (Callable): Line graph function
+
+    Returns:
+        Callable: Decorated function
+    """
+
+    def wrapper(df: pd.DataFrame) -> px.line:
+        fig = func(df)
+        fig.layout.xaxis.title = "Time"
+        fig.layout.xaxis.range = time_range
+        fig.update_xaxes(type="date")
+        return fig
+
+    return wrapper
+
+
 @figure("Generation Split")
 def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
     """Creates Plotly figure for Generation Split graph.
@@ -74,6 +94,7 @@ def generate_gen_split_fig(df: pd.DataFrame) -> px.pie:
 
 
 @figure("Generation Total")
+@line_graph
 def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Total Generation graph.
 
@@ -107,15 +128,13 @@ def generate_total_gen_fig(df: pd.DataFrame) -> px.line:
     total_gen_fig.update_layout(
         yaxis_title="GW",
     )
-    total_gen_fig.layout.xaxis.title = "Time"
-    total_gen_fig.layout.xaxis.range = time_range
     total_gen_fig.layout.yaxis.range = [-5, 70]
-    total_gen_fig.update_xaxes(type="date")
 
     return total_gen_fig
 
 
 @figure("Demand Total")
+@line_graph
 def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Total Demand graph.
 
@@ -138,14 +157,12 @@ def generate_total_dem_fig(df: pd.DataFrame) -> px.line:
     total_dem_fig.update_layout(
         yaxis_title="GW",
     )
-    total_dem_fig.layout.xaxis.title = "Time"
-    total_dem_fig.layout.xaxis.range = time_range
     total_dem_fig.layout.yaxis.range = [-5, 70]
-    total_dem_fig.update_xaxes(type="date")
     return total_dem_fig
 
 
 @figure("System Frequency")
+@line_graph
 def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for System Frequency graph.
 
@@ -169,15 +186,13 @@ def generate_system_freq_fig(df: pd.DataFrame) -> px.line:
     system_freq_fig.update_layout(
         yaxis_title="GW",
     )
-    system_freq_fig.layout.xaxis.title = "Time"
-    system_freq_fig.layout.xaxis.range = time_range
     system_freq_fig.layout.yaxis.range = [-5, 70]
-    system_freq_fig.update_xaxes(type="date")
 
     return system_freq_fig
 
 
 @figure("Intra-day Market System")
+@line_graph
 def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
     """Creates Plotly figure for Intra-day Market System graph.
 
@@ -218,21 +233,19 @@ def generate_intraday_market_sys_fig(df: pd.DataFrame) -> go.Figure:
             intraday_market_sys_fig_left.data + intraday_market_sys_fig_right.data
         )
 
-    intraday_market_sys_fig.layout.xaxis.title = "Time"
     intraday_market_sys_fig.layout.yaxis.title = "MW"
     intraday_market_sys_fig.layout.yaxis2.title = "£/MW"
-    intraday_market_sys_fig.layout.xaxis.range = time_range
     intraday_market_sys_fig.layout.yaxis.range = [-100, 100]
     intraday_market_sys_fig.layout.yaxis2.range = [-10000, 10000]
     intraday_market_sys_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
-    intraday_market_sys_fig.update_xaxes(type="date")
 
     return intraday_market_sys_fig
 
 
 @figure("Balancing Market")
+@line_graph
 def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
     """Creates Plotly figure for Balancing Market graph.
 
@@ -273,21 +286,19 @@ def generate_balancing_market_fig(df: pd.DataFrame) -> go.Figure:
             balancing_market_fig_left.data + balancing_market_fig_right.data
         )
 
-    balancing_market_fig.layout.xaxis.title = "Time"
     balancing_market_fig.layout.yaxis.title = "MW"
     balancing_market_fig.layout.yaxis2.title = "£/MW"
-    balancing_market_fig.layout.xaxis.range = time_range
     balancing_market_fig.layout.yaxis.range = [-250, 250]
     balancing_market_fig.layout.yaxis2.range = [-50000, 50000]
     balancing_market_fig.for_each_trace(
         lambda t: t.update(line=dict(color=t.marker.color))
     )
-    balancing_market_fig.update_xaxes(type="date")
 
     return balancing_market_fig
 
 
 @figure("Energy Deficit")
+@line_graph
 def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for Energy Deficit graph.
 
@@ -309,10 +320,7 @@ def generate_energy_deficit_fig(df: pd.DataFrame) -> px.line:
     energy_deficit_fig.update_layout(
         yaxis_title="MW",
     )
-    energy_deficit_fig.layout.xaxis.title = "Time"
-    energy_deficit_fig.layout.xaxis.range = time_range
     energy_deficit_fig.layout.yaxis.range = [-600, 600]
-    energy_deficit_fig.update_xaxes(type="date")
     return energy_deficit_fig
 
 
@@ -345,6 +353,7 @@ def generate_intraday_market_bids_fig(df: pd.DataFrame) -> go.Figure:
 
 
 @figure("Demand Side Response")
+@line_graph
 def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
     """Creates plotly figure for Demand Side Response graph.
 
@@ -382,18 +391,16 @@ def generate_dsr_fig(df: pd.DataFrame) -> go.Figure:
 
         dsr_fig.add_traces(dsr_fig_left.data + dsr_fig_right.data)
 
-    dsr_fig.layout.xaxis.title = "Time"  # TODO: Check units
     dsr_fig.layout.yaxis.title = "kW"
     dsr_fig.layout.yaxis2.title = "£/MW"
-    dsr_fig.layout.xaxis.range = time_range
     dsr_fig.layout.yaxis.range = [-1, 1]  # TODO: Check range
     dsr_fig.layout.yaxis2.range = [-1, 1]
     dsr_fig.for_each_trace(lambda t: t.update(line=dict(color=t.marker.color)))
-    dsr_fig.update_xaxes(type="date")
     return dsr_fig
 
 
 @figure("DSR Commands to Agents")
+@line_graph
 def generate_dsr_commands_fig(df: pd.DataFrame) -> px.line:
     """Creates Plotly figure for DSR Commands to Agents graph.
 
@@ -430,10 +437,7 @@ def generate_dsr_commands_fig(df: pd.DataFrame) -> px.line:
         yaxis_title="MW",
         legend_title=None,
     )
-    dsr_commands_fig.layout.xaxis.title = "Time"
-    dsr_commands_fig.layout.xaxis.range = time_range
     dsr_commands_fig.layout.yaxis.range = [-8, 8]
-    dsr_commands_fig.update_xaxes(type="date")
     return dsr_commands_fig
 
 

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -143,9 +143,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "Agent Activity Breakdown", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="agent_activity_breakdown_fig",
                             figure=agent_activity_breakdown_fig,
@@ -156,10 +153,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "Electric Vehicle Charging Breakdown",
-                            style={"textAlign": "center"},
-                        ),
                         dcc.Graph(
                             id="ev_charging_breakdown_fig",
                             figure=ev_charging_breakdown_fig,
@@ -170,9 +163,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "DSR Commands to Agents", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="dsr_commands_fig",
                             figure=dsr_commands_fig,

--- a/app/pages/home.py
+++ b/app/pages/home.py
@@ -1,7 +1,8 @@
 """Home Page for Dash app."""
+from pathlib import Path
 
 import dash  # type: ignore
-from dash import html  # type: ignore
+from dash import dcc, html  # type: ignore
 
 dash.register_page(__name__, path="/")
 
@@ -10,9 +11,20 @@ layout = html.Div(
     children=[
         html.H1(children="This is our Home page"),
         html.Div(
-            children="""
-        This is our Home page content.
-    """
+            children=[
+                "This is our Home page content.",
+                html.Div(
+                    [
+                        html.Div(
+                            dcc.Link(
+                                page.with_suffix("").name,
+                                href=f"/{page.with_suffix('').name}",
+                            )
+                        )
+                        for page in Path(__file__).parent.glob("*.py")
+                    ]
+                ),
+            ]
         ),
     ],
 )

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -49,9 +49,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "Intra-day Market System", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="graph-intraday-market-sys",
                             figure=intraday_market_sys_fig,
@@ -62,7 +59,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1("Balancing Market", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-balancing-market",
                             figure=balancing_market_fig,
@@ -73,7 +69,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1("Energy Deficit", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-energy-deficit",
                             figure=energy_deficit_fig,
@@ -89,10 +84,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "Intraday Market Bids and Offers",
-                            style={"textAlign": "center"},
-                        ),
                         dcc.Graph(
                             id="table-intraday-market-bids",
                             figure=intraday_market_bids_fig,
@@ -103,7 +94,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1("Demand Side Response", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-dsr",
                             figure=dsr_fig,
@@ -114,9 +104,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "32%"},
                     children=[
-                        html.H1(
-                            "DSR Commands to Agents", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="graph-dsr-commands",
                             figure=dsr_commands_fig,

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -52,7 +52,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-intraday-market-sys",
                             figure=intraday_market_sys_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -62,7 +62,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-balancing-market",
                             figure=balancing_market_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -72,7 +72,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-energy-deficit",
                             figure=energy_deficit_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -87,7 +87,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="table-intraday-market-bids",
                             figure=intraday_market_bids_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -97,7 +97,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-dsr",
                             figure=dsr_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -107,7 +107,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-dsr-commands",
                             figure=dsr_commands_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -43,7 +43,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("Weather", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="weather_fig",
                             figure=weather_fig,
@@ -54,7 +53,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("Balancing Market", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="balancing_market_fig",
                             figure=balancing_market_fig,
@@ -70,9 +68,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1(
-                            "Intra-day Market System", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="intraday_market_sys_fig",
                             figure=intraday_market_sys_fig,
@@ -83,9 +78,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1(
-                            "Reserve/Standby Generation", style={"textAlign": "center"}
-                        ),
                         dcc.Graph(
                             id="reserve_generation_fig",
                             figure=reserve_generation_fig,

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -42,7 +42,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("Generation Split", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-gen-split",
                             figure=gen_split_fig,
@@ -53,7 +52,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("Generation Total", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-gen-total",
                             figure=total_gen_fig,
@@ -69,7 +67,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("Demand Total", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-demand",
                             figure=total_dem_fig,
@@ -80,7 +77,6 @@ layout = html.Div(
                 html.Div(
                     style={"width": "48%"},
                     children=[
-                        html.H1("System Frequency", style={"textAlign": "center"}),
                         dcc.Graph(
                             id="graph-freq",
                             figure=system_freq_fig,

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -45,7 +45,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-gen-split",
                             figure=gen_split_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -55,7 +55,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-gen-total",
                             figure=total_gen_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -70,7 +70,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-demand",
                             figure=total_dem_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),
@@ -80,7 +80,7 @@ layout = html.Div(
                         dcc.Graph(
                             id="graph-freq",
                             figure=system_freq_fig,
-                            style={"height": "40vh"},
+                            style={"height": "50vh"},
                         ),
                     ],
                 ),


### PR DESCRIPTION
# Description

Moving titles to graphs rather than having them as their own div. Also set up some decorators to abstract some of the figure formatting. I've now set the total figure height in the market and supplydemand views to 100% to eliminate the black bar. I've left agent for now for reasons outlined below (also because layout for agent view is still tbd).

Also moving some figure formatting commands outside of if statements so things like axis labels and titles show even when the data is empty (i.e. upon startup)

Still to do:
- Sort out titles for SVGs

Close #81 
Close #62 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (`python -m pytest`)
- [ ] Pre-commit hooks run successfully (`pre-commit run --all-files`)
