### PR TITLE
Abstract grid layout

### DIFF
--- a/app/figures.py
+++ b/app/figures.py
@@ -588,7 +588,7 @@ def create_waffle_chart(
 
 
 @figure("Agent Activity Breakdown")
-@timestamp()
+@timestamp(y=1.05)
 def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for agent activity breakdown figure.
 
@@ -616,7 +616,7 @@ def generate_agent_activity_breakdown_fig(df: pd.DataFrame) -> go.Figure:
 
 
 @figure("Electric Vehicle Charging Breakdown")
-@timestamp()
+@timestamp(y=1.05)
 def generate_ev_charging_breakdown_fig(df: pd.DataFrame) -> go.Figure:
     """Creates waffle chart for EV charging breakdown figure.
 

--- a/app/layout.py
+++ b/app/layout.py
@@ -3,56 +3,57 @@ from dash import html  # type: ignore
 
 
 class GridBuilder:
-    """_summary_."""
+    """Class for building a grid layout of graphs."""
 
     def __init__(
         self,
         rows: int,
         cols: int,
-        row_heights: list[str] = None,  # type: ignore
-        col_widths: list[str] = None,  # type:ignore
+        row_heights: list[str] | None = None,
+        col_widths: list[str] | None = None,
     ):
-        """_summary_.
+        """Initialise grid with specified rows and columns.
 
         Args:
-            rows (int): _description_
-            cols (int): _description_
-            row_heights (list[str], optional): _description_. Defaults to None.
-            col_widths (list[str], optional): _description_. Defaults to None.
+            rows (int): Number of rows
+            cols (int): Number of columns
+            row_heights (list[str], optional): List of row heights (vh format).
+                Defaults to None.
+            col_widths (list[str], optional): List of column widths (vw format).
+                Defaults to None.
         """
+        if row_heights is None:
+            row_heights = [f"{100 / rows}vh"] * rows
+        if col_widths is None:
+            col_widths = [f"{100 / cols}vw"] * cols
+
         self.rows = rows
         self.cols = cols
         self.row_heights = row_heights
         self.col_widths = col_widths
-        self.row_heights = row_heights
-        self.col_widths = col_widths
-        if not self.row_heights:
-            self.row_heights = [f"{100 / rows}vh"] * rows
-        if not self.col_widths:
-            self.col_widths = [f"{100 / cols}%" for _ in range(cols)]
         self.grid_elements = [[None] * cols for _ in range(rows)]
 
     def add_element(self, element: html.Div, row: int, col: int) -> None:
-        """_summary_.
+        """Add an element to the grid at a specified position.
 
         Args:
-            element (html.Div): _description_
-            row (int): _description_
-            col (int): _description_
+            element (html.Div): Single div to add to the grid
+            row (int): Row index
+            col (int): Column index
 
         Raises:
-            ValueError: _description_
+            ValueError: Raised if row/column index is not in grid bounds
         """
-        if 0 <= row < self.rows and 0 <= col < self.cols:
-            self.grid_elements[row][col] = element
-        else:
+        if 0 > row >= self.rows and 0 > col >= self.cols:
             raise ValueError("Invalid row or column index.")
+        self.grid_elements[row][col] = element
 
-    def build_layout(self) -> html.Div:
-        """_summary_.
+    @property
+    def layout(self) -> html.Div:
+        """Builds a grid layout with the elements added so far.
 
         Returns:
-            html.Div: _description_
+            html.Div: The full grid layout as a div
         """
         grid_layout = html.Div(
             style={
@@ -69,8 +70,13 @@ class GridBuilder:
                     },
                     children=[
                         html.Div(
-                            style={"width": self.col_widths[j]},
-                            children=[self.grid_elements[i][j]],
+                            style={
+                                "width": self.col_widths[j],
+                                "height": self.row_heights[i],
+                            },
+                            children=[
+                                self.grid_elements[i][j],
+                            ],
                         )
                         for j in range(self.cols)
                     ],

--- a/app/layout.py
+++ b/app/layout.py
@@ -1,5 +1,5 @@
 """Module for generating figure grid layout."""
-from dash import html
+from dash import html  # type: ignore
 
 
 class GridBuilder:

--- a/app/layout.py
+++ b/app/layout.py
@@ -1,0 +1,82 @@
+"""Module for generating figure grid layout."""
+from dash import html
+
+
+class GridBuilder:
+    """_summary_."""
+
+    def __init__(
+        self,
+        rows: int,
+        cols: int,
+        row_heights: list[str] = None,  # type: ignore
+        col_widths: list[str] = None,  # type:ignore
+    ):
+        """_summary_.
+
+        Args:
+            rows (int): _description_
+            cols (int): _description_
+            row_heights (list[str], optional): _description_. Defaults to None.
+            col_widths (list[str], optional): _description_. Defaults to None.
+        """
+        self.rows = rows
+        self.cols = cols
+        self.row_heights = row_heights
+        self.col_widths = col_widths
+        self.row_heights = row_heights
+        self.col_widths = col_widths
+        if not self.row_heights:
+            self.row_heights = [f"{100 / rows}vh"] * rows
+        if not self.col_widths:
+            self.col_widths = [f"{100 / cols}%" for _ in range(cols)]
+        self.grid_elements = [[None] * cols for _ in range(rows)]
+
+    def add_element(self, element: html.Div, row: int, col: int) -> None:
+        """_summary_.
+
+        Args:
+            element (html.Div): _description_
+            row (int): _description_
+            col (int): _description_
+
+        Raises:
+            ValueError: _description_
+        """
+        if 0 <= row < self.rows and 0 <= col < self.cols:
+            self.grid_elements[row][col] = element
+        else:
+            raise ValueError("Invalid row or column index.")
+
+    def build_layout(self) -> html.Div:
+        """_summary_.
+
+        Returns:
+            html.Div: _description_
+        """
+        grid_layout = html.Div(
+            style={
+                "display": "flex",
+                "flex-direction": "column",
+                "justify-content": "space-around",
+            },
+            children=[
+                html.Div(
+                    style={
+                        "display": "flex",
+                        "justify-content": "space-around",
+                        "height": self.row_heights[i],
+                    },
+                    children=[
+                        html.Div(
+                            style={"width": self.col_widths[j]},
+                            children=[self.grid_elements[i][j]],
+                        )
+                        for j in range(self.cols)
+                    ],
+                )
+                for i in range(self.rows)
+            ],
+        )
+
+        return grid_layout

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -1,13 +1,11 @@
 """Agent view page in dash app.
 
-Seven plots:
-- Agent Locations
-- Agent Locations on SLD
+Five plots:
+- Agent and EV Locations
+- Agent and EV Locations on SLD
 - Agent Activity Breakdown
-- Electric Vehicle Location
-- Electric Vehicle Location on SLD
 - Electric Vehicle Charging Breakdown
-- DSR commands to agents.
+- DSR commands to agents
 """
 
 import dash  # type: ignore
@@ -21,6 +19,7 @@ from ..figures import (
     generate_dsr_commands_fig,
     generate_ev_charging_breakdown_fig,
 )
+from ..layout import GridBuilder
 from ..svg import (
     generate_agent_location_map_img,
     generate_agent_location_sld_img,
@@ -42,138 +41,119 @@ ev_location_sld_img = generate_ev_location_sld_img(df)
 ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(df)
 dsr_commands_fig = generate_dsr_commands_fig(df)
 
-layout = html.Div(
-    style={
-        "display": "flex",
-        "flex-direction": "column",
-        "justify-content": "space-around",
-    },
-    children=[
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        html.H1(
-                            "Agent and EV Locations",
-                            style={"textAlign": "center"},
-                        ),
-                        html.Div(
-                            style={
-                                "position": "relative",
-                                "margin": "auto",
-                                "width": "60%",
-                            },
-                            children=[
-                                html.Img(src=svg_map.url, width="100%"),
-                                html.Img(
-                                    id="agent_location_map_img",
-                                    src=agent_location_map_img,
-                                    width="100%",
-                                    style={
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "left": 0,
-                                    },
-                                ),
-                                html.Img(
-                                    id="ev_location_map_img",
-                                    src=ev_location_map_img,
-                                    width="100%",
-                                    style={
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "left": 0,
-                                    },
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        html.H1(
-                            "Agent and EV Locations on SLD",
-                            style={"textAlign": "center"},
-                        ),
-                        html.Div(
-                            style={
-                                "position": "relative",
-                                "margin": "auto",
-                                "width": "60%",
-                            },
-                            children=[
-                                html.Img(src=svg_sld.url, width="100%"),
-                                html.Img(
-                                    id="agent_location_sld_img",
-                                    src=agent_location_sld_img,
-                                    width="100%",
-                                    style={
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "left": 0,
-                                    },
-                                ),
-                                html.Img(
-                                    id="ev_location_sld_img",
-                                    src=ev_location_sld_img,
-                                    width="100%",
-                                    style={
-                                        "position": "absolute",
-                                        "top": 0,
-                                        "left": 0,
-                                    },
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="agent_activity_breakdown_fig",
-                            figure=agent_activity_breakdown_fig,
-                            style={"height": "30vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="ev_charging_breakdown_fig",
-                            figure=ev_charging_breakdown_fig,
-                            style={"height": "30vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="dsr_commands_fig",
-                            figure=dsr_commands_fig,
-                            style={"height": "30vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    ],
+grid = GridBuilder(rows=2, cols=3)
+grid.add_element(
+    html.Div(
+        children=[
+            html.H1(
+                "Agent and EV Locations",
+                style={"textAlign": "center"},
+            ),
+            html.Div(
+                style={
+                    "position": "relative",
+                    "margin": "auto",
+                    "width": "100%",
+                },
+                children=[
+                    html.Img(src=svg_map.url, width="100%"),
+                    html.Img(
+                        id="agent_location_map_img",
+                        src=agent_location_map_img,
+                        width="100%",
+                        style={
+                            "position": "absolute",
+                            "top": 0,
+                            "left": 0,
+                        },
+                    ),
+                    html.Img(
+                        id="ev_location_map_img",
+                        src=ev_location_map_img,
+                        width="100%",
+                        style={
+                            "position": "absolute",
+                            "top": 0,
+                            "left": 0,
+                        },
+                    ),
+                ],
+            ),
+        ],
+    ),
+    row=0,
+    col=0,
 )
+grid.add_element(
+    html.Div(
+        children=[
+            html.H1(
+                "Agent and EV Locations on SLD",
+                style={"textAlign": "center"},
+            ),
+            html.Div(
+                style={
+                    "position": "relative",
+                    "margin": "auto",
+                    "width": "100%",
+                },
+                children=[
+                    html.Img(src=svg_sld.url, width="100%"),
+                    html.Img(
+                        id="agent_location_sld_img",
+                        src=agent_location_sld_img,
+                        width="100%",
+                        style={
+                            "position": "absolute",
+                            "top": 0,
+                            "left": 0,
+                        },
+                    ),
+                    html.Img(
+                        id="ev_location_sld_img",
+                        src=ev_location_sld_img,
+                        width="100%",
+                        style={
+                            "position": "absolute",
+                            "top": 0,
+                            "left": 0,
+                        },
+                    ),
+                ],
+            ),
+        ],
+    ),
+    row=0,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="agent_activity_breakdown_fig",
+        figure=agent_activity_breakdown_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=0,
+)
+grid.add_element(
+    dcc.Graph(
+        id="ev_charging_breakdown_fig",
+        figure=ev_charging_breakdown_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="dsr_commands_fig",
+        figure=dsr_commands_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=2,
+)
+layout = grid.layout
 
 
 @callback(

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -13,7 +13,7 @@ Six plots (2x3):
 import dash  # type: ignore
 import pandas as pd
 import plotly.express as px  # type: ignore
-from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash import Input, Output, callback, dcc  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
 from ..figures import (
@@ -24,6 +24,7 @@ from ..figures import (
     generate_intraday_market_bids_fig,
     generate_intraday_market_sys_fig,
 )
+from ..layout import GridBuilder
 
 dash.register_page(__name__)
 
@@ -36,85 +37,63 @@ intraday_market_bids_fig = generate_intraday_market_bids_fig(df)
 dsr_fig = generate_dsr_fig(df)
 dsr_commands_fig = generate_dsr_commands_fig(df)
 
-layout = html.Div(
-    style={
-        "display": "flex",
-        "flex-direction": "column",
-        "justify-content": "space-around",
-    },
-    children=[
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-intraday-market-sys",
-                            figure=intraday_market_sys_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-balancing-market",
-                            figure=balancing_market_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-energy-deficit",
-                            figure=energy_deficit_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="table-intraday-market-bids",
-                            figure=intraday_market_bids_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-dsr",
-                            figure=dsr_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "32%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-dsr-commands",
-                            figure=dsr_commands_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    ],
+
+grid = GridBuilder(rows=2, cols=3)
+grid.add_element(
+    dcc.Graph(
+        id="graph-intraday-market-sys",
+        figure=intraday_market_sys_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=0,
+    col=0,
 )
+grid.add_element(
+    dcc.Graph(
+        id="graph-balancing-market",
+        figure=balancing_market_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=0,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="graph-energy-deficit",
+        figure=energy_deficit_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=0,
+    col=2,
+)
+grid.add_element(
+    dcc.Graph(
+        id="table-intraday-market-bids",
+        figure=intraday_market_bids_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=0,
+)
+grid.add_element(
+    dcc.Graph(
+        id="graph-dsr",
+        figure=dsr_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="graph-dsr-commands",
+        figure=dsr_commands_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=2,
+)
+layout = grid.layout
 
 
 @callback(

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -10,7 +10,7 @@ Four plots (2x2):
 
 import dash  # type: ignore
 import pandas as pd
-from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash import Input, Output, callback, dcc  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
 from ..data import WESIM
@@ -20,6 +20,7 @@ from ..figures import (
     generate_reserve_generation_fig,
     generate_weather_fig,
 )
+from ..layout import GridBuilder
 
 dash.register_page(__name__)
 
@@ -30,65 +31,44 @@ balancing_market_fig = generate_balancing_market_fig(df)
 intraday_market_sys_fig = generate_intraday_market_sys_fig(df)
 reserve_generation_fig = generate_reserve_generation_fig(WESIM)
 
-layout = html.Div(
-    style={
-        "display": "flex",
-        "flex-direction": "column",
-        "justify-content": "space-around",
-    },
-    children=[
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="weather_fig",
-                            figure=weather_fig,
-                            style={"height": "40vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="balancing_market_fig",
-                            figure=balancing_market_fig,
-                            style={"height": "40vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="intraday_market_sys_fig",
-                            figure=intraday_market_sys_fig,
-                            style={"height": "40vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="reserve_generation_fig",
-                            figure=reserve_generation_fig,
-                            style={"height": "40vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    ],
+grid = GridBuilder(rows=2, cols=2)
+grid.add_element(
+    dcc.Graph(
+        id="weather_fig",
+        figure=weather_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=0,
+    col=0,
 )
+grid.add_element(
+    dcc.Graph(
+        id="balancing_market_fig",
+        figure=balancing_market_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=0,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="intraday_market_sys_fig",
+        figure=intraday_market_sys_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=0,
+)
+grid.add_element(
+    dcc.Graph(
+        id="reserve_generation_fig",
+        figure=reserve_generation_fig,
+        style={"height": "100%", "width": "100%"},
+    ),
+    row=1,
+    col=1,
+)
+layout = grid.layout
 
 
 @callback(

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -35,6 +35,7 @@ grid.add_element(
     dcc.Graph(
         id="graph-gen-split",
         figure=gen_split_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=0,
     col=0,
@@ -43,6 +44,7 @@ grid.add_element(
     dcc.Graph(
         id="graph-gen-total",
         figure=total_gen_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=0,
     col=1,
@@ -51,6 +53,7 @@ grid.add_element(
     dcc.Graph(
         id="graph-demand",
         figure=total_dem_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=1,
     col=0,
@@ -59,11 +62,12 @@ grid.add_element(
     dcc.Graph(
         id="graph-freq",
         figure=system_freq_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=1,
     col=1,
 )
-layout = grid.build_layout()
+layout = grid.layout
 
 
 @callback(

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -11,7 +11,7 @@ Four plots (2x2):
 import dash  # type: ignore
 import pandas as pd
 import plotly.express as px  # type: ignore
-from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash import Input, Output, callback, dcc  # type: ignore
 
 from ..figures import (
     generate_gen_split_fig,
@@ -19,6 +19,7 @@ from ..figures import (
     generate_total_dem_fig,
     generate_total_gen_fig,
 )
+from ..layout import GridBuilder
 
 dash.register_page(__name__)
 
@@ -29,65 +30,40 @@ total_gen_fig = generate_total_gen_fig(df)
 total_dem_fig = generate_total_dem_fig(df)
 system_freq_fig = generate_system_freq_fig(df)
 
-layout = html.Div(
-    style={
-        "display": "flex",
-        "flex-direction": "column",
-        "justify-content": "space-around",
-    },
-    children=[
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-gen-split",
-                            figure=gen_split_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-gen-total",
-                            figure=total_gen_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        html.Div(
-            style={"display": "flex", "justify-content": "space-around"},
-            children=[
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-demand",
-                            figure=total_dem_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-                html.Div(
-                    style={"width": "48%"},
-                    children=[
-                        dcc.Graph(
-                            id="graph-freq",
-                            figure=system_freq_fig,
-                            style={"height": "50vh"},
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    ],
+grid = GridBuilder(rows=2, cols=2)
+grid.add_element(
+    dcc.Graph(
+        id="graph-gen-split",
+        figure=gen_split_fig,
+    ),
+    row=0,
+    col=0,
 )
+grid.add_element(
+    dcc.Graph(
+        id="graph-gen-total",
+        figure=total_gen_fig,
+    ),
+    row=0,
+    col=1,
+)
+grid.add_element(
+    dcc.Graph(
+        id="graph-demand",
+        figure=total_dem_fig,
+    ),
+    row=1,
+    col=0,
+)
+grid.add_element(
+    dcc.Graph(
+        id="graph-freq",
+        figure=system_freq_fig,
+    ),
+    row=1,
+    col=1,
+)
+layout = grid.build_layout()
 
 
 @callback(


### PR DESCRIPTION
# Description

Abstracting grid layout for figures into a new class. You specify the number of rows and columns in the grid, then add each element (div) individually before building the grid.

Not currently suitable for any layouts more complex than a grid. Could probably make this more flexible, as discussed below and on teams:
- allowing number of rows/columns to be dynamically adjusted when a new element is added (specifying width/height when you add the element)
- supporting a different number of columns per row
- using width/height multipliers instead of specifying absolute values


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (`python -m pytest`)
- [ ] Pre-commit hooks run successfully (`pre-commit run --all-files`)
