### PR TITLE
Use plotly for SVGs

### DIFF
--- a/app/figures.py
+++ b/app/figures.py
@@ -9,6 +9,17 @@ import plotly.graph_objects as go  # type: ignore
 from plotly.colors import DEFAULT_PLOTLY_COLORS  # type: ignore
 from plotly.subplots import make_subplots  # type: ignore
 
+from .svg import (
+    generate_map_location_svg,
+    generate_sld_location_svg,
+    get_agent_map_coordinates,
+    get_agent_sld_coordinates,
+    get_ev_map_coordinates,
+    get_ev_sld_coordinates,
+    svg_map,
+    svg_sld,
+)
+
 time_range = ["2035-01-22 04:00", "2035-01-22 11:00"]
 
 
@@ -749,3 +760,57 @@ def generate_reserve_generation_fig(wesim_data: dict[str, pd.DataFrame]) -> go.F
             y="Solar Reserve",
         )
     return reserve_generation_fig
+
+
+@figure("Agent and EV Locations")
+def generate_map_fig(df: pd.DataFrame) -> go.Figure:
+    """Creates map figure.
+
+    Args:
+        df (pd.DataFrame): Opal dataframe
+
+    Returns:
+        go.Figure: Plotly figure object
+    """
+    agent_x, agent_y = get_agent_map_coordinates(df)
+    agent_svg = generate_map_location_svg(agent_x, agent_y, colour="#6A0DAD")
+    ev_x, ev_y = get_ev_map_coordinates(df)
+    ev_svg = generate_map_location_svg(ev_x, ev_y, colour="#fcba03")
+
+    map_fig = go.Figure()
+    args = {"x": 0, "y": 1, "xref": "paper", "yref": "paper", "sizex": 1, "sizey": 1}
+    map_fig.add_layout_image(source=svg_map.url, **args)
+    map_fig.add_layout_image(source=agent_svg.url, **args)
+    map_fig.add_layout_image(source=ev_svg.url, **args)
+    map_fig.update_layout(yaxis=dict(scaleanchor="x"), plot_bgcolor="rgba(0,0,0,0)")
+    map_fig.update_xaxes(visible=False)
+    map_fig.update_yaxes(visible=False)
+    return map_fig
+
+
+@figure("Agent and EV Locations on SLD")
+def generate_sld_fig(df: pd.DataFrame) -> go.Figure:
+    """Creates SLD figure.
+
+    Args:
+        df (pd.DataFrame): Opal dataframe
+
+    Returns:
+        go.Figure: Plotly figure object
+    """
+    agent_location_data = get_agent_sld_coordinates(df)
+    agent_svg = generate_sld_location_svg(
+        agent_location_data, angle_mid=180, colour="#6A0DAD"
+    )
+    ev_location_data = get_ev_sld_coordinates(df)
+    ev_svg = generate_sld_location_svg(ev_location_data, angle_mid=0, colour="#fcba03")
+
+    sld_fig = go.Figure()
+    args = {"x": 0, "y": 1, "xref": "paper", "yref": "paper", "sizex": 1, "sizey": 1}
+    sld_fig.add_layout_image(source=svg_sld.url, **args)
+    sld_fig.add_layout_image(source=agent_svg.url, **args)
+    sld_fig.add_layout_image(source=ev_svg.url, **args)
+    sld_fig.update_layout(yaxis=dict(scaleanchor="x"), plot_bgcolor="rgba(0,0,0,0)")
+    sld_fig.update_xaxes(visible=False)
+    sld_fig.update_yaxes(visible=False)
+    return sld_fig

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -12,116 +12,42 @@ import dash  # type: ignore
 import pandas as pd
 import plotly.express as px  # type: ignore
 import plotly.graph_objects as go  # type: ignore
-from dash import Input, Output, callback, dcc, html  # type: ignore
+from dash import Input, Output, callback, dcc  # type: ignore
 
 from ..figures import (
     generate_agent_activity_breakdown_fig,
     generate_dsr_commands_fig,
     generate_ev_charging_breakdown_fig,
+    generate_map_fig,
+    generate_sld_fig,
 )
 from ..layout import GridBuilder
-from ..svg import (
-    generate_agent_location_map_img,
-    generate_agent_location_sld_img,
-    generate_ev_location_map_img,
-    generate_ev_location_sld_img,
-    svg_map,
-    svg_sld,
-)
 
 dash.register_page(__name__)
 
 df = pd.DataFrame({"Col": [0]})
 
-agent_location_map_img = generate_agent_location_map_img(df)
-agent_location_sld_img = generate_agent_location_sld_img(df)
+sld_fig = generate_sld_fig(df)
+map_fig = generate_map_fig(df)
 agent_activity_breakdown_fig = generate_agent_activity_breakdown_fig(df)
-ev_location_map_img = generate_ev_location_map_img(df)
-ev_location_sld_img = generate_ev_location_sld_img(df)
 ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(df)
 dsr_commands_fig = generate_dsr_commands_fig(df)
 
 grid = GridBuilder(rows=2, cols=3)
 grid.add_element(
-    html.Div(
-        children=[
-            html.H1(
-                "Agent and EV Locations",
-                style={"textAlign": "center"},
-            ),
-            html.Div(
-                style={
-                    "position": "relative",
-                    "margin": "auto",
-                    "width": "100%",
-                },
-                children=[
-                    html.Img(src=svg_map.url, width="100%"),
-                    html.Img(
-                        id="agent_location_map_img",
-                        src=agent_location_map_img,
-                        width="100%",
-                        style={
-                            "position": "absolute",
-                            "top": 0,
-                            "left": 0,
-                        },
-                    ),
-                    html.Img(
-                        id="ev_location_map_img",
-                        src=ev_location_map_img,
-                        width="100%",
-                        style={
-                            "position": "absolute",
-                            "top": 0,
-                            "left": 0,
-                        },
-                    ),
-                ],
-            ),
-        ],
+    dcc.Graph(
+        id="map_fig",
+        figure=map_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=0,
     col=0,
 )
 grid.add_element(
-    html.Div(
-        children=[
-            html.H1(
-                "Agent and EV Locations on SLD",
-                style={"textAlign": "center"},
-            ),
-            html.Div(
-                style={
-                    "position": "relative",
-                    "margin": "auto",
-                    "width": "100%",
-                },
-                children=[
-                    html.Img(src=svg_sld.url, width="100%"),
-                    html.Img(
-                        id="agent_location_sld_img",
-                        src=agent_location_sld_img,
-                        width="100%",
-                        style={
-                            "position": "absolute",
-                            "top": 0,
-                            "left": 0,
-                        },
-                    ),
-                    html.Img(
-                        id="ev_location_sld_img",
-                        src=ev_location_sld_img,
-                        width="100%",
-                        style={
-                            "position": "absolute",
-                            "top": 0,
-                            "left": 0,
-                        },
-                    ),
-                ],
-            ),
-        ],
+    dcc.Graph(
+        id="sld_fig",
+        figure=sld_fig,
+        style={"height": "100%", "width": "100%"},
     ),
     row=0,
     col=1,
@@ -158,11 +84,9 @@ layout = grid.layout
 
 @callback(
     [
-        Output("agent_location_map_img", "src"),
-        Output("agent_location_sld_img", "src"),
+        Output("map_fig", "figure"),
+        Output("sld_fig", "figure"),
         Output("agent_activity_breakdown_fig", "figure"),
-        Output("ev_location_map_img", "src"),
-        Output("ev_location_sld_img", "src"),
         Output("ev_charging_breakdown_fig", "figure"),
         Output("dsr_commands_fig", "figure"),
     ],
@@ -170,7 +94,7 @@ layout = grid.layout
 )
 def update_figures(
     n_intervals: int,
-) -> tuple[str, str, go.Figure, str, str, go.Figure, px.line]:
+) -> tuple[go.Figure, go.Figure, go.Figure, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
@@ -178,25 +102,21 @@ def update_figures(
             indexes by 1 every 7 seconds.
 
     Returns:
-        tuple[str, str, px.pie, str, str, px.pie, px.line]:
+        tuple[go.Figure, go.Figure, go.Figure, go.Figure, px.line]:
             The new figures.
     """
     from ..data import DF_OPAL
 
     # TODO: ensure each figure is using the correct dataframe
-    agent_location_fig = generate_agent_location_map_img(DF_OPAL)
-    agent_location_sld_img = generate_agent_location_sld_img(DF_OPAL)
+    map_fig = generate_map_fig(DF_OPAL)
+    sld_fig = generate_sld_fig(DF_OPAL)
     agent_activity_breakdown_fig = generate_agent_activity_breakdown_fig(DF_OPAL)
-    ev_location_fig = generate_ev_location_map_img(DF_OPAL)
-    ev_location_sld_img = generate_ev_location_sld_img(DF_OPAL)
     ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(DF_OPAL)
     dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
     return (
-        agent_location_fig,
-        agent_location_sld_img,
+        map_fig,
+        sld_fig,
         agent_activity_breakdown_fig,
-        ev_location_fig,
-        ev_location_sld_img,
         ev_charging_breakdown_fig,
         dsr_commands_fig,
     )

--- a/app/svg.py
+++ b/app/svg.py
@@ -230,34 +230,6 @@ def generate_sld_location_svg(
     return SVG(svg)
 
 
-def generate_agent_location_sld_img(df: pd.DataFrame) -> str:
-    """Generates an SVG url of agent locations for placement over the SLD image.
-
-    Args:
-        df (pd.DataFrame): TODO: Opal or DSR?
-
-    Returns:
-        str: SVG url for direct use by html.Img
-    """
-    location_data = get_agent_sld_coordinates(df)
-    svg = generate_sld_location_svg(location_data, angle_mid=180, colour="#6A0DAD")
-    return svg.url
-
-
-def generate_ev_location_sld_img(df: pd.DataFrame) -> str:
-    """Generates an SVG url of EV locations for placement over the SLD image.
-
-    Args:
-        df (pd.DataFrame): TODO: Opal or DSR?
-
-    Returns:
-        str: SVG url for direct use by html.Img
-    """
-    location_data = get_ev_sld_coordinates(df)
-    svg = generate_sld_location_svg(location_data, angle_mid=0, colour="#fcba03")
-    return svg.url
-
-
 def generate_map_location_svg(
     x_coordinates: list[float],
     y_coordinates: list[float],
@@ -288,31 +260,3 @@ def generate_map_location_svg(
         )
     svg += "</svg>"
     return SVG(svg)
-
-
-def generate_agent_location_map_img(df: pd.DataFrame) -> str:
-    """Generates an SVG url of agent locations for placement over the SLD image.
-
-    Args:
-        df (pd.DataFrame): TODO: Opal or DSR?
-
-    Returns:
-        str: SVG url for direct use by html.Img
-    """
-    x_coordinates, y_coordinates = get_agent_map_coordinates(df)
-    svg = generate_map_location_svg(x_coordinates, y_coordinates, colour="#6A0DAD")
-    return svg.url
-
-
-def generate_ev_location_map_img(df: pd.DataFrame) -> str:
-    """Generates an SVG url of EV locations for placement over the SLD image.
-
-    Args:
-        df (pd.DataFrame): TODO: Opal or DSR?
-
-    Returns:
-        str: SVG url for direct use by html.Img
-    """
-    x_coordinates, y_coordinates = get_ev_map_coordinates(df)
-    svg = generate_map_location_svg(x_coordinates, y_coordinates, colour="#fcba03")
-    return svg.url


### PR DESCRIPTION
# Description

Using plotly to display svgs. This allows us the define titles in the same way as the other figures, keeps formatting consistent, and simplifies the layout specification.

I've also made it so the whole figure updates every iteration rather than just the dots representing agents/EVs as before. This is just to simplify the layout specification as it allows us to use a single figure object rather than multiple objects per figure. Presumably this could be addressed with partial property updates (https://dash.plotly.com/partial-properties), but as I don't see any noticeable performance issues I'll leave this for now.

Close #95 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (`python -m pytest`)
- [ ] Pre-commit hooks run successfully (`pre-commit run --all-files`)
