### PR TITLE
Rearrange graphs

### DIFF
--- a/app/core_api.py
+++ b/app/core_api.py
@@ -35,12 +35,12 @@ webrtc = {"url": f"{API_URL}/app/webrtc", "states": {"load": "ScreenShare"}}
 INIT_SECTIONS = {
     "Control": {"space": "Tablet", "app": html("control")},
     "NMX": {"space": "PC01-Top", "app": webrtc},
-    "Balance of Supply and Demand": {"space": "PC01-Left", "app": html("supplydemand")},
+    "Balance of Supply and Demand": {"space": "PC01-Left", "app": html("market")},
     "Markets and Reserve": {"space": "PC01-Right", "app": html("marketsreserve")},
     "NMX Geographic Map": {"space": "PC02-Top", "app": webrtc},
     "NMX 11kV Schematic": {"space": "PC02-Left", "app": webrtc},
     "NMX Issues": {"space": "PC02-Right", "app": webrtc},
-    "Market": {"space": "Hub01", "app": html("market")},
+    "Market": {"space": "Hub01", "app": html("supplydemand")},
     "Agent": {"space": "Hub02", "app": html("agent")},
 }
 

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -1,8 +1,6 @@
 """Market view page in dash app.
 
-Six plots (2x3):
-- Intra-day market system
-- Balancing market
+Four plots (2x2):
 - Energy deficit
 - Intraday market bids and offers
 - Demand side response
@@ -17,12 +15,10 @@ from dash import Input, Output, callback, dcc  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
 from ..figures import (
-    generate_balancing_market_fig,
     generate_dsr_commands_fig,
     generate_dsr_fig,
     generate_energy_deficit_fig,
     generate_intraday_market_bids_fig,
-    generate_intraday_market_sys_fig,
 )
 from ..layout import GridBuilder
 
@@ -30,33 +26,13 @@ dash.register_page(__name__)
 
 df = pd.DataFrame({"Col": [0]})
 
-intraday_market_sys_fig = generate_intraday_market_sys_fig(df)
-balancing_market_fig = generate_balancing_market_fig(df)
 energy_deficit_fig = generate_energy_deficit_fig(df)
 intraday_market_bids_fig = generate_intraday_market_bids_fig(df)
 dsr_fig = generate_dsr_fig(df)
 dsr_commands_fig = generate_dsr_commands_fig(df)
 
 
-grid = GridBuilder(rows=2, cols=3)
-grid.add_element(
-    dcc.Graph(
-        id="graph-intraday-market-sys",
-        figure=intraday_market_sys_fig,
-        style={"height": "100%", "width": "100%"},
-    ),
-    row=0,
-    col=0,
-)
-grid.add_element(
-    dcc.Graph(
-        id="graph-balancing-market",
-        figure=balancing_market_fig,
-        style={"height": "100%", "width": "100%"},
-    ),
-    row=0,
-    col=1,
-)
+grid = GridBuilder(rows=2, cols=2)
 grid.add_element(
     dcc.Graph(
         id="graph-energy-deficit",
@@ -64,7 +40,7 @@ grid.add_element(
         style={"height": "100%", "width": "100%"},
     ),
     row=0,
-    col=2,
+    col=0,
 )
 grid.add_element(
     dcc.Graph(
@@ -72,8 +48,8 @@ grid.add_element(
         figure=intraday_market_bids_fig,
         style={"height": "100%", "width": "100%"},
     ),
-    row=1,
-    col=0,
+    row=0,
+    col=1,
 )
 grid.add_element(
     dcc.Graph(
@@ -82,7 +58,7 @@ grid.add_element(
         style={"height": "100%", "width": "100%"},
     ),
     row=1,
-    col=1,
+    col=0,
 )
 grid.add_element(
     dcc.Graph(
@@ -91,15 +67,13 @@ grid.add_element(
         style={"height": "100%", "width": "100%"},
     ),
     row=1,
-    col=2,
+    col=1,
 )
 layout = grid.layout
 
 
 @callback(
     [
-        Output("graph-intraday-market-sys", "figure"),
-        Output("graph-balancing-market", "figure"),
         Output("graph-energy-deficit", "figure"),
         Output("table-intraday-market-bids", "figure"),
         Output("graph-dsr", "figure"),
@@ -109,7 +83,7 @@ layout = grid.layout
 )
 def update_figures(
     n_intervals: int,
-) -> tuple[go.Figure, go.Figure, px.line, go.Figure, go.Figure, px.line]:
+) -> tuple[px.line, go.Figure, go.Figure, px.line]:
     """Function to update the plots in this page.
 
     Args:
@@ -117,20 +91,16 @@ def update_figures(
             indexes by 1 every 7 seconds.
 
     Returns:
-        tuple[go.Figure, go.Figure, px.line, go.Figure, go.Figure, px.line]:
+        tuple[px.line, go.Figure, go.Figure, px.line]:
             The new figures.
     """
     from ..data import DF_OPAL
 
-    intraday_market_sys_fig = generate_intraday_market_sys_fig(DF_OPAL)
-    balancing_market_fig = generate_balancing_market_fig(DF_OPAL)
     energy_deficit_fig = generate_energy_deficit_fig(DF_OPAL)
     intraday_market_bids_fig = generate_intraday_market_bids_fig(DF_OPAL)
     dsr_fig = generate_dsr_fig(df)  # TODO: replace with df_dsr when available
     dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
     return (
-        intraday_market_sys_fig,
-        balancing_market_fig,
         energy_deficit_fig,
         intraday_market_bids_fig,
         dsr_fig,


### PR DESCRIPTION
# Description

Switching the market view to PC1-left and the supplydemand view to Hub1. Also removing two graphs from the market view (these are duplicates of graphs that already appear on the marketsreserve view)

Close #78 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [x] Pre-commit hooks run successfully (`pre-commit run --all-files`)
