### PR TITLE
Slider to update playback speed

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,12 +1,8 @@
 """Sets up the server for the Dash app."""
 import dash  # type: ignore
-from dash import Dash, dcc, html  # type: ignore
+from dash import Dash, Input, Output, callback, dcc, html  # type: ignore
 
 from . import log
-
-##################
-interval = 7000
-##################
 
 app = Dash(__package__, use_pages=True, update_title=None)
 
@@ -17,12 +13,33 @@ app.layout = html.Div(
     },
     children=[
         dash.page_container,
-        dcc.Interval(id="figure_interval", interval=interval),
+        dcc.Interval(id="figure_interval"),
     ],
 )
 
 server = app.server
 log.info("Gridlington Visualisation System is running...")
+
+
+@callback(
+    [Output("figure_interval", "disabled"), Output("figure_interval", "interval")],
+    [Input("figure_interval", "n_intervals")],
+)
+def update_interval(
+    n_intervals: int,
+) -> tuple[bool, int]:
+    """_summary_.
+
+    Args:
+        n_intervals (int): _description_
+
+    Returns:
+        tuple[bool, int]: _description_
+    """
+    from .data import data_ended
+    from .pages.control import interval
+
+    return (data_ended, interval)
 
 
 if __name__ == "__main__":

--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ app.layout = html.Div(
     children=[
         dash.page_container,
         dcc.Interval(id="figure_interval"),
+        dcc.Interval(id="sync_interval", interval=1000),
     ],
 )
 
@@ -23,7 +24,7 @@ log.info("Gridlington Visualisation System is running...")
 
 @callback(
     [Output("figure_interval", "disabled"), Output("figure_interval", "interval")],
-    [Input("figure_interval", "n_intervals")],
+    [Input("sync_interval", "n_intervals")],
 )
 def update_figure_interval(
     n_intervals: int,

--- a/app/app.py
+++ b/app/app.py
@@ -25,21 +25,22 @@ log.info("Gridlington Visualisation System is running...")
     [Output("figure_interval", "disabled"), Output("figure_interval", "interval")],
     [Input("figure_interval", "n_intervals")],
 )
-def update_interval(
+def update_figure_interval(
     n_intervals: int,
 ) -> tuple[bool, int]:
-    """_summary_.
+    """Callback to synchronise the figure interval with the data interval.
 
     Args:
-        n_intervals (int): _description_
+        n_intervals (int): Number of times the figures have updated
 
     Returns:
-        tuple[bool, int]: _description_
+        data_ended (bool): Whether the data has ended
+        interval (int): The interval between updates
     """
     from .data import data_ended
     from .pages.control import interval
 
-    return (data_ended, interval)
+    return data_ended, interval
 
 
 if __name__ == "__main__":

--- a/app/data.py
+++ b/app/data.py
@@ -6,10 +6,6 @@ from dash.exceptions import PreventUpdate  # type: ignore
 from . import LIVE_MODEL, log
 from .datahub_api import get_opal_data, get_wesim_data  # , get_dsr_data
 
-##################
-interval = 7000
-##################
-
 DF_OPAL = pd.DataFrame({"Col": [0]})
 
 WESIM_START_DATE = "2035-01-22 00:00"  # corresponding to hour 0 TODO: check
@@ -24,7 +20,7 @@ if LIVE_MODEL:
 else:
     WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
-data_interval = dcc.Interval(id="data_interval", interval=interval)
+data_interval = dcc.Interval(id="data_interval")
 data_ended = False
 
 

--- a/app/data.py
+++ b/app/data.py
@@ -25,22 +25,22 @@ else:
     WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
 data_interval = dcc.Interval(id="data_interval", interval=interval)
-empty_output = dcc.Store(id="empty", data=[])
 
 
 @callback(
-    [Output("empty", "data")],
+    [Output("data_interval", "disabled")],
     [Input("data_interval", "n_intervals")],
 )
-def update_data(n_intervals: int) -> tuple[list[None],]:
-    """Function to update the data.
+def update_data(n_intervals: int) -> tuple[bool,]:
+    """Function to update OPAL data.
 
     Args:
-        n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+        n_intervals (int): The number of times the data has updated.
+            indexes by 1 every interval.
 
     Returns:
-        Opal data dictionary
+        tuple[bool,]: Boolean that specifies whether the iterator should
+            terminate
 
     """
     global DF_OPAL
@@ -49,12 +49,15 @@ def update_data(n_intervals: int) -> tuple[list[None],]:
         raise PreventUpdate
 
     if LIVE_MODEL:
-        log.debug("Updating plots from live model")
+        log.debug("Updating data from live model")
         data_opal = get_opal_data()
         DF_OPAL = pd.DataFrame(**data_opal)  # type: ignore[call-overload]
     else:
         from .pre_set_data import OPAL_DATA
 
-        log.debug("Updating plots with pre-set data")
+        log.debug("Updating pre-set data")
         DF_OPAL = OPAL_DATA.loc[:n_intervals]
-    return ([],)
+        if n_intervals == len(OPAL_DATA):
+            log.debug("Reached end of pre-set data")
+            return (True,)
+    return (False,)

--- a/app/data.py
+++ b/app/data.py
@@ -25,6 +25,7 @@ else:
     WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
 data_interval = dcc.Interval(id="data_interval", interval=interval)
+data_ended = False
 
 
 @callback(
@@ -43,7 +44,7 @@ def update_data(n_intervals: int) -> tuple[bool,]:
             terminate
 
     """
-    global DF_OPAL
+    global DF_OPAL, data_ended
 
     if n_intervals is None:
         raise PreventUpdate
@@ -59,5 +60,5 @@ def update_data(n_intervals: int) -> tuple[bool,]:
         DF_OPAL = OPAL_DATA.loc[:n_intervals]
         if n_intervals == len(OPAL_DATA):
             log.debug("Reached end of pre-set data")
-            return (True,)
-    return (False,)
+            data_ended = True
+    return (data_ended,)

--- a/app/data.py
+++ b/app/data.py
@@ -6,6 +6,8 @@ from dash.exceptions import PreventUpdate  # type: ignore
 from . import LIVE_MODEL, log
 from .datahub_api import get_opal_data, get_wesim_data  # , get_dsr_data
 
+N_INTERVALS_DATA = 0
+
 DF_OPAL = pd.DataFrame({"Col": [0]})
 
 WESIM_START_DATE = "2035-01-22 00:00"  # corresponding to hour 0 TODO: check
@@ -21,7 +23,6 @@ else:
     WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
 data_interval = dcc.Interval(id="data_interval")
-data_ended = False
 
 
 @callback(
@@ -40,11 +41,12 @@ def update_data(n_intervals: int) -> tuple[bool,]:
             terminate
 
     """
-    global DF_OPAL, data_ended
+    global DF_OPAL, N_INTERVALS_DATA
 
     if n_intervals is None:
         raise PreventUpdate
 
+    data_ended = False
     if LIVE_MODEL:
         log.debug("Updating data from live model")
         data_opal = get_opal_data()
@@ -57,4 +59,6 @@ def update_data(n_intervals: int) -> tuple[bool,]:
         if n_intervals == len(OPAL_DATA):
             log.debug("Reached end of pre-set data")
             data_ended = True
+
+    N_INTERVALS_DATA = n_intervals
     return (data_ended,)

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -14,6 +14,7 @@ import plotly.express as px  # type: ignore
 import plotly.graph_objects as go  # type: ignore
 from dash import Input, Output, callback, dcc  # type: ignore
 
+from .. import log
 from ..figures import (
     generate_agent_activity_breakdown_fig,
     generate_dsr_commands_fig,
@@ -99,7 +100,7 @@ def update_figures(
 
     Args:
         n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+            indexes by 1 every interval.
 
     Returns:
         tuple[go.Figure, go.Figure, go.Figure, go.Figure, px.line]:
@@ -113,6 +114,7 @@ def update_figures(
     agent_activity_breakdown_fig = generate_agent_activity_breakdown_fig(DF_OPAL)
     ev_charging_breakdown_fig = generate_ev_charging_breakdown_fig(DF_OPAL)
     dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
+    log.debug("Updating figures on Agent page")
     return (
         map_fig,
         sld_fig,

--- a/app/pages/agent.py
+++ b/app/pages/agent.py
@@ -91,7 +91,7 @@ layout = grid.layout
         Output("ev_charging_breakdown_fig", "figure"),
         Output("dsr_commands_fig", "figure"),
     ],
-    [Input("figure_interval", "n_intervals")],
+    [Input("figure_interval", "data")],
 )
 def update_figures(
     n_intervals: int,

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -10,7 +10,6 @@ from ..data import data_interval
 
 dash.register_page(__name__)
 
-interval = 7000
 
 options = [key for key in core.INIT_SECTIONS.keys() if key != "Control"]
 
@@ -183,7 +182,7 @@ layout = html.Div(
                                         min=2,
                                         max=10,
                                         step=1,
-                                        value=interval / 1000,
+                                        value=7,
                                     ),
                                     style={"width": "100%"},
                                 ),
@@ -334,8 +333,5 @@ def default_button_click(n_clicks: int | None) -> list[str]:
 )
 def update_data_interval(value: int) -> tuple[int]:
     """Callback to update the data interval."""
-    global interval
-
     log.debug(f"Update interval set to {value} seconds.")
-    interval = value * 1000
-    return (interval,)
+    return (value * 1000,)

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -327,3 +327,12 @@ def default_button_click(n_clicks: int | None) -> list[str]:
         get_default("PC02-Left"),
         get_default("PC02-Right"),
     ]
+
+
+@callback(
+    [Output("data_interval", "interval")], [Input("update-interval-slider", "value")]
+)
+def update_interval(value: int) -> list[int]:
+    """Returns the update interval value."""
+    log.debug(f"Update interval set to {value} seconds.")
+    return [value * 1000]

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -10,6 +10,9 @@ from ..data import data_interval
 
 dash.register_page(__name__)
 
+##################
+interval = 7000
+##################
 
 options = [key for key in core.INIT_SECTIONS.keys() if key != "Control"]
 
@@ -179,10 +182,10 @@ layout = html.Div(
                                 html.Div(
                                     dcc.Slider(
                                         id="update-interval-slider",
-                                        min=1,
+                                        min=2,
                                         max=10,
                                         step=1,
-                                        value=data_interval.interval / 1000,
+                                        value=interval / 1000,
                                     ),
                                     style={"width": "100%"},
                                 ),
@@ -333,5 +336,8 @@ def default_button_click(n_clicks: int | None) -> list[str]:
 )
 def update_interval(value: int) -> list[int]:
     """Returns the update interval value."""
+    global interval
+
     log.debug(f"Update interval set to {value} seconds.")
+    interval = value * 1000
     return [value * 1000]

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -4,8 +4,8 @@ import dash  # type: ignore
 from dash import Input, Output, State, callback, ctx, dcc, html  # type: ignore
 from dash_iconify import DashIconify  # type: ignore
 
+from .. import LIVE_MODEL, log
 from .. import core_api as core
-from .. import log
 from ..data import data_interval
 
 dash.register_page(__name__)
@@ -193,9 +193,9 @@ layout = html.Div(
                             ],
                             style={
                                 "width": "40%",
-                                "display": "flex",
                                 "flex-direction": "column",
                                 "justify-content": "center",
+                                "display": "none" if LIVE_MODEL else "flex",
                             },
                         ),
                         get_button("default", "iconoir:undo"),

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -334,8 +334,8 @@ def default_button_click(n_clicks: int | None) -> list[str]:
 @callback(
     [Output("data_interval", "interval")], [Input("update-interval-slider", "value")]
 )
-def update_interval(value: int) -> list[int]:
-    """Returns the update interval value."""
+def update_data_interval(value: int) -> list[int]:
+    """Callback to update the data interval."""
     global interval
 
     log.debug(f"Update interval set to {value} seconds.")

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -10,9 +10,7 @@ from ..data import data_interval
 
 dash.register_page(__name__)
 
-##################
 interval = 7000
-##################
 
 options = [key for key in core.INIT_SECTIONS.keys() if key != "Control"]
 

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -334,10 +334,10 @@ def default_button_click(n_clicks: int | None) -> list[str]:
 @callback(
     [Output("data_interval", "interval")], [Input("update-interval-slider", "value")]
 )
-def update_data_interval(value: int) -> list[int]:
+def update_data_interval(value: int) -> tuple[int]:
     """Callback to update the data interval."""
     global interval
 
     log.debug(f"Update interval set to {value} seconds.")
     interval = value * 1000
-    return [value * 1000]
+    return (interval,)

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -171,11 +171,33 @@ layout = html.Div(
                         "display": "flex",
                         "justify-content": "space-around",
                         "padding": "10px",
-                        "width": "66%",
-                        "margin": "auto",
                     },
                     children=[
                         get_button("update", "mdi:tick"),
+                        html.Div(
+                            children=[
+                                html.Div(
+                                    dcc.Slider(
+                                        id="update-interval-slider",
+                                        min=1,
+                                        max=10,
+                                        step=1,
+                                        value=7,
+                                    ),
+                                    style={"width": "100%"},
+                                ),
+                                html.Label(
+                                    "Update Interval (s)",
+                                    style={"text-align": "center"},
+                                ),
+                            ],
+                            style={
+                                "width": "40%",
+                                "display": "flex",
+                                "flex-direction": "column",
+                                "justify-content": "center",
+                            },
+                        ),
                         get_button("default", "iconoir:undo"),
                     ],
                 ),

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -6,7 +6,7 @@ from dash_iconify import DashIconify  # type: ignore
 
 from .. import core_api as core
 from .. import log
-from ..data import data_interval, empty_output
+from ..data import data_interval
 
 dash.register_page(__name__)
 
@@ -182,7 +182,7 @@ layout = html.Div(
                                         min=1,
                                         max=10,
                                         step=1,
-                                        value=7,
+                                        value=data_interval.interval / 1000,
                                     ),
                                     style={"width": "100%"},
                                 ),
@@ -216,7 +216,6 @@ layout = html.Div(
             ],
         ),
         data_interval,
-        empty_output,
     ],
 )
 

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -80,7 +80,7 @@ layout = grid.layout
         Output("graph-dsr", "figure"),
         Output("graph-dsr-commands", "figure"),
     ],
-    [Input("figure_interval", "n_intervals")],
+    [Input("figure_interval", "data")],
 )
 def update_figures(
     n_intervals: int,

--- a/app/pages/market.py
+++ b/app/pages/market.py
@@ -14,6 +14,7 @@ import plotly.express as px  # type: ignore
 from dash import Input, Output, callback, dcc  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
+from .. import log
 from ..figures import (
     generate_dsr_commands_fig,
     generate_dsr_fig,
@@ -88,7 +89,7 @@ def update_figures(
 
     Args:
         n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+            indexes by 1 every interval.
 
     Returns:
         tuple[px.line, go.Figure, go.Figure, px.line]:
@@ -100,6 +101,7 @@ def update_figures(
     intraday_market_bids_fig = generate_intraday_market_bids_fig(DF_OPAL)
     dsr_fig = generate_dsr_fig(df)  # TODO: replace with df_dsr when available
     dsr_commands_fig = generate_dsr_commands_fig(DF_OPAL)
+    log.debug("Updating figures on Market page")
     return (
         energy_deficit_fig,
         intraday_market_bids_fig,

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -77,7 +77,7 @@ layout = grid.layout
         Output("balancing_market_fig", "figure"),
         Output("intraday_market_sys_fig", "figure"),
     ],
-    [Input("figure_interval", "n_intervals")],
+    [Input("figure_interval", "data")],
 )
 def update_figures(
     n_intervals: int,

--- a/app/pages/marketsreserve.py
+++ b/app/pages/marketsreserve.py
@@ -13,6 +13,7 @@ import pandas as pd
 from dash import Input, Output, callback, dcc  # type: ignore
 from plotly import graph_objects as go  # type: ignore
 
+from .. import log
 from ..data import WESIM
 from ..figures import (
     generate_balancing_market_fig,
@@ -85,7 +86,7 @@ def update_figures(
 
     Args:
         n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+            indexes by 1 every interval.
 
     Returns:
         tuple[go.Figure, go.Figure]: The new figures.
@@ -94,6 +95,7 @@ def update_figures(
 
     balancing_market_fig = generate_balancing_market_fig(DF_OPAL)
     intraday_market_sys_fig = generate_intraday_market_sys_fig(DF_OPAL)
+    log.debug("Updating figures of Markets and Reserve page")
     return (
         balancing_market_fig,
         intraday_market_sys_fig,

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -78,7 +78,7 @@ layout = grid.layout
         Output("graph-demand", "figure"),
         Output("graph-freq", "figure"),
     ],
-    [Input("figure_interval", "n_intervals")],
+    [Input("figure_interval", "data")],
 )
 def update_figures(
     n_intervals: int,

--- a/app/pages/supplydemand.py
+++ b/app/pages/supplydemand.py
@@ -13,6 +13,7 @@ import pandas as pd
 import plotly.express as px  # type: ignore
 from dash import Input, Output, callback, dcc  # type: ignore
 
+from .. import log
 from ..figures import (
     generate_gen_split_fig,
     generate_system_freq_fig,
@@ -86,7 +87,7 @@ def update_figures(
 
     Args:
         n_intervals (int): The number of times this page has updated.
-            indexes by 1 every 7 seconds.
+            indexes by 1 every interval.
 
     Returns:
         tuple[px.pie, px.line, px.line, px.line]: The new figures.
@@ -97,4 +98,5 @@ def update_figures(
     total_gen_fig = generate_total_gen_fig(DF_OPAL)
     total_dem_fig = generate_total_dem_fig(DF_OPAL)
     system_freq_fig = generate_system_freq_fig(DF_OPAL)
+    log.debug("Updating figures on Supply & Demand page")
     return gen_split_fig, total_gen_fig, total_dem_fig, system_freq_fig


### PR DESCRIPTION
# Description

Currently we have two `dcc.Interval` objects (`data_interval` and `figure_interval`), in charge of updating the data and figures. The time-interval of these two objects is specified manually in the code, and fixed to 7 seconds for both. This way we get data and figure updates at the same rate, but the interval objects are not linked in any way so updates don't necessarily occur on the same cycle (i.e. the figures may wait several seconds after the data has updated before updating themselves). Also, since the time-interval is fixed in the code it can't be changed from the app.

I have three main goals with this pull request:
1. Synchronise figure updates with data updates (i.e. have figures detect when the data changes and update accordingly, rather than running on their own interval)
2. Terminate updates once the pre-set data has reached the end
3. Add a slider to the control page so the time-interval can be adjusted from the app

The overall approach is fairly convoluted but the simplest I could come up with and seems to work. The main steps can be summarised as follows: 
- I have changed `figure_interval` to a `dcc.Store` object which just contains a value and doesn't increment on its own. The `update_figure_interval` callback runs in the background and is responsible for synchronising `figure_interval` with `data_interval` (via the `N_INTERVALS_DATA` global variable).
- The `update_figures` callback on each of the figure pages then responds whenever `figure_interval` changes and triggers the figures to update
- Once the pre-set data has reached the end, the `update_data` callback will switch the `disabled` property of `data_interval` to `True`. This prevents `data_interval` from incrementing any further, therefore terminating data and figure updates.
- The time-interval for updates is now set from the control app. I've added a slider on the middle of the page (ranging from 2s to 10s, with a default value of 7s). This is linked to a callback (`update_data_interval`) which updates the `interval` attribute of `data_interval`.

Note: When the live model is being used this will only change the rate at which the data is pulled in and the figures updated, it  doesn't interact with the model in any way so won't change the speed of the simulation or anything like that. When using the pre-set data, we add one new timepoint each interval, so this does change the rate at which new data appears.


Control app:

<img width="627" alt="Screenshot 2023-12-13 142437" src="https://github.com/ImperialCollegeLondon/gridlington-vis/assets/23723407/2c39e8eb-6582-476d-ab85-a2e627f03be8">

Close #97 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [x] Pre-commit hooks run successfully (`pre-commit run --all-files`)
