### PR TITLE
Assign functionality to start & stop buttons

### DIFF
--- a/app/datahub_api.py
+++ b/app/datahub_api.py
@@ -103,22 +103,10 @@ def start_model() -> str:
         str: Message to display on the control app
     """
     try:
-        # Get signal to see if model is already running
-        start_signal = request_datahub("start").json()
-        if start_signal:
+        if request_datahub("start").json():
             return "Model is already running"
-
-        # If not running, send signal to start
-        requests.post(f"{DH_URL}/set_model_signals", json={"start": True})
-
-        # Get signal to see if model has started properly
-        start_signal = request_datahub("start").json()
-        return (
-            "Model started successfully"
-            if start_signal
-            else "Failed to start the model"
-        )
-
+        response = requests.post(f"{DH_URL}/set_model_signals", params={"start": True})
+        return response.text
     except (DataHubConnectionError, DataHubRequestError):
         return "Failed to connect to the DataHub"
 
@@ -130,20 +118,9 @@ def stop_model() -> str:
         str: Message to display on the control app
     """
     try:
-        # Get signal to see if model is already stopped
-        stop_signal = request_datahub("stop").json()
-        if stop_signal:
+        if request_datahub("stop").json():
             return "Model is not running"
-
-        # If running, send signal to stop
-        requests.post(f"{DH_URL}/set_model_signals", json={"start": False})
-
-        # Get signal to see if model has stopped properly
-        stop_signal = request_datahub("stop").json()
-        return (
-            "Model stopped successfully"
-            if not stop_signal
-            else "Failed to stop the model"
-        )
+        response = requests.post(f"{DH_URL}/set_model_signals", params={"start": False})
+        return response.text
     except (DataHubConnectionError, DataHubRequestError):
         return "Failed to connect to the DataHub"

--- a/app/datahub_api.py
+++ b/app/datahub_api.py
@@ -94,3 +94,56 @@ def get_wesim_data() -> dict[str, dict]:  # type: ignore[type-arg]
     req = request_datahub("wesim")
 
     return req.json()["data"]
+
+
+def start_model() -> str:
+    """Function for starting the model.
+
+    Returns:
+        str: Message to display on the control app
+    """
+    try:
+        # Get signal to see if model is already running
+        start_signal = request_datahub("start").json()
+        if start_signal:
+            return "Model is already running"
+
+        # If not running, send signal to start
+        requests.post(f"{DH_URL}/set_model_signals", json={"start": True})
+
+        # Get signal to see if model has started properly
+        start_signal = request_datahub("start").json()
+        return (
+            "Model started successfully"
+            if start_signal
+            else "Failed to start the model"
+        )
+
+    except (DataHubConnectionError, DataHubRequestError):
+        return "Failed to connect to the DataHub"
+
+
+def stop_model() -> str:
+    """Function for stopping the model.
+
+    Returns:
+        str: Message to display on the control app
+    """
+    try:
+        # Get signal to see if model is already stopped
+        stop_signal = request_datahub("stop").json()
+        if stop_signal:
+            return "Model is not running"
+
+        # If running, send signal to stop
+        requests.post(f"{DH_URL}/set_model_signals", json={"start": False})
+
+        # Get signal to see if model has stopped properly
+        stop_signal = request_datahub("stop").json()
+        return (
+            "Model stopped successfully"
+            if not stop_signal
+            else "Failed to stop the model"
+        )
+    except (DataHubConnectionError, DataHubRequestError):
+        return "Failed to connect to the DataHub"

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -359,13 +359,15 @@ def stop_button_click(n_clicks: int | None) -> tuple[str, bool]:
 def restart_button_click(n_clicks: int | None) -> tuple[str, int, bool]:
     """Function for restart button.
 
+    TODO: this should send a signal to DataHub to restart the model
+
     Args:
         n_clicks (int | None): Number of times the button has been clicked
 
     Returns:
         str: Message for the control app
         int: 0 sends data interval back to the beginning
-        bool: Whether to disable data updates
+        bool: False (re-)enables data updates
     """
     log.debug("Clicked Restart Button!")
     try:

--- a/app/pages/control.py
+++ b/app/pages/control.py
@@ -1,6 +1,7 @@
 """Controller Page for Dash app."""
 
 import dash  # type: ignore
+import requests
 from dash import Input, Output, State, callback, dcc, html  # type: ignore
 from dash_iconify import DashIconify  # type: ignore
 
@@ -301,47 +302,77 @@ def default_button_click(n_clicks: int | None) -> list[str]:
 
 
 @callback(
-    Output("message", "children", allow_duplicate=True),
-    Output("data_interval", "disabled", allow_duplicate=True),
+    [
+        Output("message", "children", allow_duplicate=True),
+        Output("data_interval", "disabled", allow_duplicate=True),
+    ],
     [Input("button_start", "n_clicks")],
     prevent_initial_call=True,
 )
 def start_button_click(n_clicks: int | None) -> tuple[str, bool]:
-    """Function for start button."""
-    log.debug("Clicked Start Button!")
-    if LIVE_MODEL:
-        message = start_model()
-    else:
-        message = "Clicked Start Button!"
+    """Function for start button.
+
+    Args:
+        n_clicks (int | None): Number of times the button has been clicked
+
+    Returns:
+        str: Message to display on the control app
+        bool: Whether to disable data updates
+    """
+    message = start_model() if LIVE_MODEL else "Playback started"
+    log.debug(message)
     return message, False
 
 
 @callback(
-    Output("message", "children", allow_duplicate=True),
-    Output("data_interval", "disabled", allow_duplicate=True),
+    [
+        Output("message", "children", allow_duplicate=True),
+        Output("data_interval", "disabled", allow_duplicate=True),
+    ],
     [Input("button_stop", "n_clicks")],
     prevent_initial_call=True,
 )
 def stop_button_click(n_clicks: int | None) -> tuple[str, bool]:
-    """Function for stop button."""
-    log.debug("Clicked Stop Button!")
-    if LIVE_MODEL:
-        message = stop_model()
-    else:
-        message = "Clicked Stop Button!"
+    """Function for stop button.
+
+    Args:
+        n_clicks (int | None): Number of times the button has been clicked
+
+    Returns:
+        str: Message to display on the control app
+        bool: Whether to disable data updates
+    """
+    message = stop_model() if LIVE_MODEL else "Playback stopped"
+    log.debug(message)
     return message, True
 
 
 @callback(
-    Output("message", "children", allow_duplicate=True),
+    [
+        Output("message", "children", allow_duplicate=True),
+        Output("data_interval", "n_intervals"),
+        Output("data_interval", "disabled", allow_duplicate=True),
+    ],
     [Input("button_restart", "n_clicks")],
     prevent_initial_call=True,
 )
-def restart_button_click(n_clicks: int | None) -> list[str]:
-    """Function for restart button. TODO."""
+def restart_button_click(n_clicks: int | None) -> tuple[str, int, bool]:
+    """Function for restart button.
+
+    Args:
+        n_clicks (int | None): Number of times the button has been clicked
+
+    Returns:
+        str: Message for the control app
+        int: 0 sends data interval back to the beginning
+        bool: Whether to disable data updates
+    """
     log.debug("Clicked Restart Button!")
-    core.refresh_sections()
-    return ["Clicked Restart Button!"]
+    try:
+        core.refresh_sections()
+    except requests.exceptions.ConnectionError:
+        pass
+    return "Clicked Restart Button!", 0, False
 
 
 @callback(

--- a/tests/test_control_view.py
+++ b/tests/test_control_view.py
@@ -1,76 +1,50 @@
-from contextvars import copy_context
+from app.pages.control import (
+    default_button_click,
+    restart_button_click,
+    start_button_click,
+    stop_button_click,
+    update_button_click,
+    update_data_interval,
+)
 
-from dash._callback_context import context_value  # type: ignore
-from dash._utils import AttributeDict  # type: ignore
 
-
-def test_control_view_callback(mocker):
-    """Test for Control View callback function and buttons."""
-    from app.pages.control import update_button_click
-
-    def run_callback():
-        context_value.set(
-            AttributeDict(
-                **{"triggered_inputs": [{"prop_id": f"{button_id}.n_clicks"}]}
-            )
-        )
-        return update_button_click(
-            buttons[0],
-            buttons[1],
-            buttons[2],
-            buttons[3],
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-        )
-
+def test_update_button_callback(mocker):
     """Test Update Button."""
-    buttons = [1, None, None, None]
-    button_id = "button_update"
-
-    ctx = copy_context()
     patched_assign_sections = mocker.patch(
-        "app.core_api.assign_sections", return_value=button_id
+        "app.core_api.assign_sections", return_value="button_update"
     )
-    output = ctx.run(run_callback)
+    output = update_button_click(0, "", "", "", "", "", "", "", "")
     patched_assign_sections.assert_called_once()
-    assert output[0] == button_id
+    assert output[0] == "button_update"
 
+
+def test_start_button_callback():
     """Test Start Button."""
-    buttons = [None, 1, None, None]
-    button_id = "button_start"
+    output = start_button_click(0)
+    assert output[1] is False
 
-    ctx = copy_context()
-    output = ctx.run(run_callback)
-    assert output[0] == "Clicked Start Button!"
 
+def test_stop_button_callback():
     """Test Stop Button."""
-    buttons = [None, None, 1, None]
-    button_id = "button_stop"
+    output = stop_button_click(0)
+    assert output[1] is True
 
-    ctx = copy_context()
-    output = ctx.run(run_callback)
-    assert output[0] == "Clicked Stop Button!"
 
-    """Test Restart Button."""
-    buttons = [None, None, None, 1]
-    button_id = "button_restart"
-
-    ctx = copy_context()
+def test_restart_button_callback(mocker):
+    """Test Reset Button."""
     patched_refresh_sections = mocker.patch("app.core_api.refresh_sections")
-    output = ctx.run(run_callback)
+    output = restart_button_click(0)
     patched_refresh_sections.assert_called_once()
-    assert output[0] == "Clicked Restart Button!"
+    assert output[1] == 0
 
 
 def test_default_button_callback():
     """Test Default Button."""
-    from app.pages.control import default_button_click
-
     output = default_button_click(0)
     assert output[0] == "Dropdowns returned to default values. Click tick to assign."
+
+
+def test_data_interval_slider_callback():
+    """Test Interval Slider."""
+    output = update_data_interval(2)
+    assert output[0] == 2000


### PR DESCRIPTION
# Description

This PR adds functionality to the start, stop and restart buttons in the control app.

Most of the changes can be found in `control.py`. This used to contain one large callback function (`update_button_click`) responsible for all the button callbacks (which were mostly empty), but since #92 Adrian has started moving button callbacks into their own functions which I think is a good move so I've followed suit here. I have written three new callbacks for the start, stop and restart buttons. The start and stop buttons are responsible for starting/stopping the live model, which it does via the new `start_model` and `stop_model` functions in `datahub_api.py`. These interact with the DataHub API introduced in [this PR](https://github.com/ImperialCollegeLondon/gridlington-datahub/pull/192/files), which modifies the DataHub variable `model_running` which is tracked by the model.  I hope I've done this correctly, however it's difficult for me to test without access to the live model. The start/stop buttons also interact with `data_interval` to start/stop data and figure updates in the vis system. The restart button sends `data_interval` back to the beginning, which resets the pre-set data. It already effectively did this when connected to the OVE (via `core.refresh_sections()`), but now it also works outside the OVE. In theory I think this button should also send a restart signal to the model via the DataHub, but it doesn't seem to me like this is possible yet, so I've left this as a TODO. (EDIT: Actually I _think_ stopping the model also restarts it, so this would just be a stop call followed by a start call - I will update)

I also had to rewrite some of the tests. The diffs look messy, but really I'm just moving the tests for each button into their own functions, and modifying tests for the start, stop and restart buttons in accordance with my changes.


Close #41 #61 #48

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [x] Pre-commit hooks run successfully (`pre-commit run --all-files`)
