### PR TITLE
Enable pre set data in Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There is also a requirements to have the OpenVidu server running - see [Deployin
 
 1. Make sure nothing's running
 2. Run `bash run_develop.sh` for vis system to run config script and `docker-compose.yml`
-   - For production, use `run.sh`
+   - For production, use `run.sh` when using pre-set data, or `run_live.sh` when using the live model.
 3. Go to OVE Core at the IP address defined in the `API_URL` environment variable you will now find in `docker-compose.yml`
 4. Go to OpenVidu IP address and manually trust website (OPENVIDU_HOST in the `docker-compose.yml`)
 5. Log in with username: admin, password: (OPENVIDU_SECRET from docker-compose.yml)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,5 +11,6 @@ logging.config.dictConfig(logging_dict_config)
 log = logging.getLogger("api_logger")
 log.debug("Logging is configured.")
 
+DEVELOP = os.environ.get("DEVELOP", False)
 LIVE_MODEL = os.environ.get("LIVE_MODEL", False)
 log.debug("Using Live Model" if LIVE_MODEL else "Using Pre-Set Data")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,6 @@ logging.config.dictConfig(logging_dict_config)
 log = logging.getLogger("api_logger")
 log.debug("Logging is configured.")
 
-DEVELOP = os.environ.get("DEVELOP", False)
+PRODUCTION = os.environ.get("PRODUCTION", False)
 LIVE_MODEL = os.environ.get("LIVE_MODEL", False)
 log.debug("Using Live Model" if LIVE_MODEL else "Using Pre-Set Data")

--- a/app/data.py
+++ b/app/data.py
@@ -4,7 +4,7 @@ import pandas as pd
 from dash import Input, Output, callback, dcc  # type: ignore
 from dash.exceptions import PreventUpdate  # type: ignore
 
-from . import DEVELOP, LIVE_MODEL, log
+from . import LIVE_MODEL, PRODUCTION, log
 from .datahub_api import get_opal_data, get_wesim_data  # , get_dsr_data
 
 N_INTERVALS_DATA = 0
@@ -13,15 +13,15 @@ DF_OPAL = pd.DataFrame({"Col": [0]})
 
 WESIM_START_DATE = "2035-01-22 00:00"  # corresponding to hour 0 TODO: check
 
-if DEVELOP:
-    WESIM = {"df": pd.DataFrame({"Col": [0]})}
-else:
+if PRODUCTION:
     WESIM = {key: pd.DataFrame(**item) for key, item in get_wesim_data().items()}
     for df in WESIM.values():
         if "Hour" in df.columns:
             df["Time"] = (
                 pd.Timestamp(WESIM_START_DATE) + pd.to_timedelta(df["Hour"], unit="h")
             ).astype(str)
+else:
+    WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
 data_interval = dcc.Interval(id="data_interval")
 

--- a/app/data.py
+++ b/app/data.py
@@ -4,7 +4,7 @@ import pandas as pd
 from dash import Input, Output, callback, dcc  # type: ignore
 from dash.exceptions import PreventUpdate  # type: ignore
 
-from . import LIVE_MODEL, log
+from . import DEVELOP, LIVE_MODEL, log
 from .datahub_api import get_opal_data, get_wesim_data  # , get_dsr_data
 
 N_INTERVALS_DATA = 0
@@ -13,15 +13,15 @@ DF_OPAL = pd.DataFrame({"Col": [0]})
 
 WESIM_START_DATE = "2035-01-22 00:00"  # corresponding to hour 0 TODO: check
 
-if LIVE_MODEL:
+if DEVELOP:
+    WESIM = {"df": pd.DataFrame({"Col": [0]})}
+else:
     WESIM = {key: pd.DataFrame(**item) for key, item in get_wesim_data().items()}
     for df in WESIM.values():
         if "Hour" in df.columns:
             df["Time"] = (
                 pd.Timestamp(WESIM_START_DATE) + pd.to_timedelta(df["Hour"], unit="h")
             ).astype(str)
-else:
-    WESIM = {"df": pd.DataFrame({"Col": [0]})}
 
 data_interval = dcc.Interval(id="data_interval")
 

--- a/configure.py
+++ b/configure.py
@@ -26,7 +26,12 @@ def get_ip_address() -> str:
     return ip
 
 
-def generate_docker_compose(template_file: str, ip: str, develop: bool = False) -> None:
+def generate_docker_compose(
+    template_file: str,
+    ip: str,
+    develop: bool = False,
+    live_model: bool = False,
+) -> None:
     """Generate the docker-compose.yml file.
 
     Uses a template file and the IP address of the machine.
@@ -34,7 +39,9 @@ def generate_docker_compose(template_file: str, ip: str, develop: bool = False) 
     Args:
         template_file: Path to the template file.
         ip: IP address of the machine.
-        develop: Flag for when running in develop mode.
+        develop: Flag for when running in develop mode (localhost for datahub).
+        live_model: Flag for when running with a live model. This requires an available
+            connection to a datahub, either in production or local for develop.
 
     Returns:
         None
@@ -81,10 +88,13 @@ def generate_docker_compose(template_file: str, ip: str, develop: bool = False) 
         docker_compose["services"]["dash"]["volumes"] += ["./app:/app"]
         docker_compose["services"]["dash"]["environment"]["DH_URL"] = "http://127.0.0.1"
         docker_compose["services"]["dash"]["environment"]["LOG_LEVEL"] = "DEBUG"
+        docker_compose["services"]["dash"]["environment"]["DEVELOP"] = "true"
     else:
         docker_compose["services"]["dash"][
             "image"
         ] = "ghcr.io/imperialcollegelondon/gridlington-vis:latest"
+
+    if live_model:
         docker_compose["services"]["dash"]["environment"]["LIVE_MODEL"] = "true"
 
     # Configure logging for nginx
@@ -105,4 +115,5 @@ if __name__ == "__main__":
         "docker-compose.setup.ove.yml",
         ip,
         develop="develop" in sys.argv,
+        live_model="live_model" in sys.argv,
     )

--- a/configure.py
+++ b/configure.py
@@ -88,8 +88,8 @@ def generate_docker_compose(
         docker_compose["services"]["dash"]["volumes"] += ["./app:/app"]
         docker_compose["services"]["dash"]["environment"]["DH_URL"] = "http://127.0.0.1"
         docker_compose["services"]["dash"]["environment"]["LOG_LEVEL"] = "DEBUG"
-        docker_compose["services"]["dash"]["environment"]["DEVELOP"] = "true"
     else:
+        docker_compose["services"]["dash"]["environment"]["PRODUCTION"] = "true"
         docker_compose["services"]["dash"][
             "image"
         ] = "ghcr.io/imperialcollegelondon/gridlington-vis:latest"

--- a/configure.py
+++ b/configure.py
@@ -41,8 +41,7 @@ def generate_docker_compose(template_file: str, ip: str, develop: bool = False) 
     """
     lines_to_replace = {
         "OVE_HOST": f"{ip}:8080",
-        # TODO: Point to the on-prem openvidu (keep as port 4443)
-        "OPENVIDU_HOST": "https://146.179.34.13:4443",
+        "OPENVIDU_HOST": f"https://{ip}:4443",
         "PLOT_URL": f"{ip}:8050",
         "DH_URL": f"{ip}:80",
     }

--- a/run_live.sh
+++ b/run_live.sh
@@ -1,0 +1,2 @@
+python3 configure.py live_model
+docker-compose up -d


### PR DESCRIPTION
# Description

This PR allows the vis system to be run in production mode as either a pre-set data run, or a live model run. It is related to #113 as it addresses the issue with not being able to run the pre-set data in production mode (ie using the pulled image from GitHub instead of building it from source). But it does not allow the switch to be made after the system has started.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (`python -m pytest`)
- [ ] Pre-commit hooks run successfully (`pre-commit run --all-files`)
