### PR TITLE
Enable `pre-release` tag for published images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository }}
-          # tags: |
-          #   type=raw,value=latest,enable={{is_default_branch}}
+          tags: |
+            type=semver,pattern={{latest}}
+            type=raw,value=latest,enable={{is_default_branch}}
       - run: echo ${{ steps.meta.outputs.tags }}
-      - run: echo ${{ steps.meta.outputs.labels }}
       # - name: Build and push Docker image
       #   uses: docker/build-push-action@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{!github.event.release.prerelease}}
-            type=raw,value=pre-release,enable={{github.event.release.prerelease}}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=pre-release,enable=${{ github.event.release.prerelease }}
       # - name: Build and push Docker image
       #   uses: docker/build-push-action@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-on: [push, release]
+on: [release]
 
 jobs:
   test:
@@ -6,7 +6,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-20.04
-    # needs: test
+    needs: test
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -23,8 +23,8 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
       - run: echo ${{ steps.meta.outputs.tags }}
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   test:
@@ -21,8 +23,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{!github.event.prerelease}}
-            type=raw,value=pre-release,enable={{!github.event.prerelease}}
+            type=raw,value=latest,enable={{!github.event.release.prerelease}}
+            type=raw,value=pre-release,enable={{github.event.release.prerelease}}
       # - name: Build and push Docker image
       #   uses: docker/build-push-action@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-20.04
-    needs: test
+    # needs: test
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -19,8 +19,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+          # tags: |
+          #   type=raw,value=latest,enable={{is_default_branch}}
       - run: echo ${{ steps.meta.outputs.tags }}
       - run: echo ${{ steps.meta.outputs.labels }}
       # - name: Build and push Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
             type=raw,value=pre-release,enable=${{ github.event.release.prerelease }}
+            type=raw,value=stable,enable=${{ !github.event.release.prerelease && github.ref == 'refs/heads/main'}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-on: [release]
+on: [push, release]
 
 jobs:
   test:
@@ -19,8 +19,12 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+      - run: echo ${{ steps.meta.outputs.tags }}
+      - run: echo ${{ steps.meta.outputs.labels }}
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{latest}}
+            type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
       - run: echo ${{ steps.meta.outputs.tags }}
       # - name: Build and push Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
             type=raw,value=pre-release,enable=${{ github.event.release.prerelease }}
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{is_default_branch}}
-      - run: echo ${{ steps.meta.outputs.tags }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+            type=raw,value=latest,enable={{!github.event.prerelease}}
+            type=raw,value=pre-release,enable={{!github.event.prerelease}}
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}

--- a/run_pre_release.sh
+++ b/run_pre_release.sh
@@ -1,0 +1,2 @@
+python3 configure.py version pre-release
+docker-compose up -d

--- a/run_stable.sh
+++ b/run_stable.sh
@@ -1,2 +1,2 @@
-python3 configure.py version v0.3.2
+python3 configure.py version stable
 docker-compose up -d

--- a/run_version.sh
+++ b/run_version.sh
@@ -1,0 +1,7 @@
+if [ "$1" == "" ]; then
+    >&2 echo "You must provide a version number (i.e. v0.3.2) or tag (i.e. latest)"
+    exit 1
+fi
+
+python3 configure.py version $1
+docker-compose up -d


### PR DESCRIPTION
### Release tagging
This PR adapts the release workflow so that the docker containers will be tagged with `latest` or `pre-release` depending on if the release is tagged as such. It also adds a `stable` tag to any non-pre-release that is released from the main branch. This is because it's possible to make `latest` releases from any branch.

You can see the pre-release from this branch here: https://github.com/ImperialCollegeLondon/gridlington-vis/releases/tag/v0.3.3-beta

And you can see the `pre-release` tag has bee successfully applied to v0.3.3-beta here https://github.com/ImperialCollegeLondon/gridlington-vis/pkgs/container/gridlington-vis

It also ensures the release workflow only runs once instead of 3 times as it was doing before.

### Helper scripts
There are two new helper scripts to run the system and one changed one:
- `run_stable.sh` - changed to get the image tagged as `stable`
- `run_pre_release.sh` - gets the image tagged as `pre-release`
- `run_version.sh` - gets the image tagged with the version specified. Example usage: `bash run_version.sh v0.3.2`