### PR TITLE
Change metadata action to get any tag for docker tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{raw}}
+            type=ref,event=tag
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
             type=raw,value=pre-release,enable=${{ github.event.release.prerelease }}
             type=raw,value=stable,enable=${{ !github.event.release.prerelease && github.event.release.target_commitish == 'main'}}


### PR DESCRIPTION
Previously it was only allowing tags that were valid semantic versioning https://semver.org and ignoring them otherwise. This meant versions with and underscore _ instead of a dash were not successfully tagging the images. Now any tag should work.

It is still recommended to use valid semantic versioning for tags.